### PR TITLE
Reworked Getting Started Guides, Readme, and Created FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-# AnkiCollab-Plugin
+<h1 style="text-align: center;">AnkiCollab-Plugin</h1>
+
+<p style="text-align: center;"> 📚<i> A free, collaborative, deck creation platform for <a href="https://apps.ankiweb.net/">Anki</a>.</i> 📝</p>
+
+## Introduction
+
+AnkiCollab is an open-source, free, collaboration tool to create and share Anki decks. If you ever wanted to split up the work of making cards, AnkiCollab offers a platform to make this possible.
+
 The source code for the Anki Plugin of https://www.ankicollab.com/
 
-Anki Plugin Page: https://ankiweb.net/shared/info/1957538407
+[Anki Plugin Page](https://ankiweb.net/shared/info/1957538407)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ AnkiCollab is an open-source, free, collaboration tool to create and share Anki 
 We have two separate Getting Started guides for [maintainers](https://github.com/CravingCrates/AnkiCollab-Plugin/blob/main/getting_started_maintainer.md) and [subscribers](https://github.com/CravingCrates/AnkiCollab-Plugin/blob/main/getting_started_subscriber.md). Check out our [FAQ](https://github.com/CravingCrates/AnkiCollab-Plugin/blob/main/faq.md) for extra help.
 
 ## Installing the Addon
+
 [AnkiCollab Add-on Page](https://ankiweb.net/shared/info/1957538407)
 
 Before you start, make sure you are using the latest version of Anki found [here](https://apps.ankiweb.net/). If you've never used Anki before, there is a great [Getting Started](https://docs.ankiweb.net/getting-started.html) guide in the Anki manual.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<h1 style="text-align: center;">AnkiCollab-Plugin</h1>
+<h1 align="center">AnkiCollab-Plugin</h1>
 
-<p style="text-align: center;"> 📚<i> A free, collaborative, deck creation platform for <a href="https://apps.ankiweb.net/">Anki</a>.</i> 📝</p>
+<p align="center"> 📚<i> A free, collaborative, deck creation platform for <a href="https://apps.ankiweb.net/">Anki</a>.</i> 📝</p>
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">AnkiCollab-Plugin</h1>
 
 <p align="center"> 📚<i> A free, collaborative, deck creation platform for <a href="https://apps.ankiweb.net/">Anki</a>.</i> 📝</p>
-<p align="center"><a href="https://ankicollab.com/">AnkiCollab.com</a> | <a href="https://discord.com/invite/9x4DRxzqwM">Discord</a></p>
+<p align="center"><a href="https://ankicollab.com/">AnkiCollab.com</a> | <a href="https://discord.gg/9x4DRxzqwM">Discord</a></p>
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you ever lose this code, you can always find it on [AnkiCollab add-on page](h
 
 ![A blue arrow pointing to AnkiCollab's addon code on the Anki Addon page.](https://i.imgur.com/oTlWGHF.png)
 
-Inside of Anki, go Tools → Add-ons → Get Add-ons. From here, a box should pop up where you can enter the code.
+Inside of Anki desktop app, go `Tools → Add-ons → Get Add-ons`. From here, a box should pop up where you can enter the code.
 
 ![Anki's install add-on window.](https://i.imgur.com/7X6fULn.png)
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,38 @@
 <h1 align="center">AnkiCollab-Plugin</h1>
 
 <p align="center"> 📚<i> A free, collaborative, deck creation platform for <a href="https://apps.ankiweb.net/">Anki</a>.</i> 📝</p>
+<p align="center"><a href="https://ankicollab.com/">AnkiCollab.com</a> | <a href="https://discord.com/invite/9x4DRxzqwM">Discord</a></p>
 
 ## Introduction
 
-AnkiCollab is an open-source, free, collaboration tool to create and share Anki decks. If you ever wanted to split up the work of making cards, AnkiCollab offers a platform to make this possible.
+AnkiCollab is an open-source, free, collaboration tool to create and share Anki decks. New workflows and projects are possible with collaboration. Some possible opportunities:
 
-The source code for the Anki Plugin of https://www.ankicollab.com/
+- Split up the work of making cards!
+  - Person A makes cards for chapter 1, person B makes cards for chapter 2, person C makes cards for chapter 3.
+- Professional Revisions
+  - Let's say you and your friends make a deck for your Spanish class. After it's done, you can get a native speaker (or even your teacher!) to go through all your cards and make corrections. After the corrections are accepted, everyone receives a polished deck!
 
-[Anki Plugin Page](https://ankiweb.net/shared/info/1957538407)
+## Getting Started Guides
+
+We have two separate Getting Started guides for [maintainers](https://github.com/CravingCrates/AnkiCollab-Plugin/blob/main/getting_started_maintainer.md) and [subscribers](https://github.com/CravingCrates/AnkiCollab-Plugin/blob/main/getting_started_subscriber.md). Check out our [FAQ](https://github.com/CravingCrates/AnkiCollab-Plugin/blob/main/faq.md) for extra help.
+
+## Installing the Addon
+[AnkiCollab Add-on Page](https://ankiweb.net/shared/info/1957538407)
+
+Before you start, make sure you are using the latest version of Anki found [here](https://apps.ankiweb.net/). If you've never used Anki before, there is a great [Getting Started](https://docs.ankiweb.net/getting-started.html) guide in the Anki manual.
+
+Every add-on in the Anki ecosystem is installed using an **add-on code**. AnkiCollab's code is `1957538407`.
+
+If you ever lose this code, you can always find it on [AnkiCollab add-on page](https://ankiweb.net/shared/info/1957538407). Scroll down a bit and you'll find it in a little box.
+
+![A blue arrow pointing to AnkiCollab's addon code on the Anki Addon page.](https://i.imgur.com/oTlWGHF.png)
+
+Inside of Anki, go Tools → Add-ons → Get Add-ons. From here, a box should pop up where you can enter the code.
+
+![Anki's install add-on window.](https://i.imgur.com/7X6fULn.png)
+
+Click OK and relaunch Anki to finish the installation.
+
+You can confirm that the installation was successful by checking the toolbar for AnkiCollab.
+
+![A blue arrow point at the toolbar of Anki showing an AnkiCollab tab.](https://i.imgur.com/IMHBCXx.png)

--- a/faq.md
+++ b/faq.md
@@ -1,0 +1,36 @@
+# Frequently Asked Questions
+
+<details close>
+<summary>How do I delete a deck?</summary>
+There is currently no way to delete decks published to <a href="https://ankicollab.com/decks">AnkiCollab.com/Decks</a>. If you'd like a deck removed, please join our <a href="https://discord.com/invite/9x4DRxzqwM">Discord</a> and let us know! This feature is high on the priority list!
+</details>
+
+<details close>
+<summary>How do I make a deck private?</summary>
+There is currently no way to upload a deck privately, but you can expect this soon!
+</details>
+
+<details close>
+<summary>Can I suggest a card to be deleted?</summary>
+Currently, there is no way to delete individual cards from a deck uploaded to <a href="https://ankicollab.com/decks">AnkiCollab.com/Decks</a>. As a workaround, suggest a tag like <code>#!DELETE</code> indicating that you want a card deleted.
+</details>
+
+<details close>
+<summary>Does AnkiCollab handle multiple profiles?</summary>
+AnkiCollab does not currently respect separate Anki profiles. If you subscribe to a deck on one profile, then switch to another, it will redownload the fresh deck. A workaround for this is to disable the addon (Tools → Add-ons → Select AnkiCollab → Toggle Enabled).
+</details>
+
+<details close>
+<summary>Does media get stored on AnkiCollab? How do subscribers get deck media?</summary>
+AnkiCollab does not upload media (images, audio, etc.) when publishing a deck or suggesting changes. If a deck has media, the maintainer should have a link available for you to download.
+</details>
+
+<details close>
+<summary>How I put a description on the Deck Browser?</summary>
+When you initially publish a deck, the deck description is also uploaded and can be seen on AnkiCollab's deck browser page. If you want to change it, please let us know in our Discord as this is currently a manual process.
+</details>
+
+<details close>
+<summary>How are deck settings handled?</summary>
+Deck settings — learning steps, new card limits, maximum interval, etc. — are not uploaded when publishing a deck. When a subscriber downloads a deck, their default deck options are assigned. If you want a subscriber to use specific settings, make a note of them in the deck description.
+</details>

--- a/faq.md
+++ b/faq.md
@@ -1,19 +1,6 @@
 # Frequently Asked Questions
 
-<details close>
-<summary>How do I delete a deck?</summary>
-There is currently no way to delete decks published to <a href="https://ankicollab.com/decks">AnkiCollab.com/Decks</a>. If you'd like a deck removed, please join our <a href="https://discord.com/invite/9x4DRxzqwM">Discord</a> and let us know! This feature is high on the priority list!
-</details>
-
-<details close>
-<summary>How do I make a deck private?</summary>
-There is currently no way to upload a deck privately, but you can expect this soon!
-</details>
-
-<details close>
-<summary>Can I suggest a card to be deleted?</summary>
-Currently, there is no way to delete individual cards from a deck uploaded to <a href="https://ankicollab.com/decks">AnkiCollab.com/Decks</a>. As a workaround, suggest a tag like <code>#!DELETE</code> indicating that you want a card deleted.
-</details>
+## General
 
 <details close>
 <summary>Does AnkiCollab handle multiple profiles?</summary>
@@ -26,11 +13,30 @@ AnkiCollab does not upload media (images, audio, etc.) when publishing a deck or
 </details>
 
 <details close>
-<summary>How I put a description on the Deck Browser?</summary>
-When you initially publish a deck, the deck description is also uploaded and can be seen on AnkiCollab's deck browser page. If you want to change it, please let us know in our Discord as this is currently a manual process.
+<summary>How are deck settings handled?</summary>
+Deck settings — learning steps, new card limits, maximum interval, etc. — are not uploaded when publishing a deck. When a subscriber downloads a deck, their default deck options are assigned. If you want a subscriber to use specific settings, make a note of them in the deck description.
+</details>
+
+## Subscriber
+
+<details close>
+<summary>Can I suggest a card to be deleted?</summary>
+Currently, there is no way to delete individual cards from a deck uploaded to <a href="https://ankicollab.com/decks">AnkiCollab.com/Decks</a>. As a workaround, suggest a tag like <code>#!DELETE</code> indicating that you want a card deleted.
+</details>
+
+## Maintainer
+
+<details close>
+<summary>How do I delete a deck?</summary>
+There is currently no way to delete decks published to <a href="https://ankicollab.com/decks">AnkiCollab.com/Decks</a>. If you'd like a deck removed, please join our <a href="https://discord.com/invite/9x4DRxzqwM">Discord</a> and let us know! This feature is high on the priority list!
 </details>
 
 <details close>
-<summary>How are deck settings handled?</summary>
-Deck settings — learning steps, new card limits, maximum interval, etc. — are not uploaded when publishing a deck. When a subscriber downloads a deck, their default deck options are assigned. If you want a subscriber to use specific settings, make a note of them in the deck description.
+<summary>How do I make a deck private?</summary>
+There is currently no way to upload a deck privately, but you can expect this soon!
+</details>
+
+<details close>
+<summary>How I put a description on the Deck Browser?</summary>
+When you initially publish a deck, the deck description is also uploaded and can be seen on AnkiCollab's deck browser page. If you want to change it, please let us know in our Discord as this is currently a manual process.
 </details>

--- a/faq.md
+++ b/faq.md
@@ -9,7 +9,7 @@
 
 <details close>
 <summary><b>Does AnkiCollab handle multiple profiles?</b></summary>
-AnkiCollab does not currently respect separate Anki profiles. If you subscribe to a deck on one profile, then switch to another, it will redownload the fresh deck. A workaround for this is to disable the addon. <code>Tools → Add-ons → Select AnkiCollab → Toggle Enabled</code>.
+AnkiCollab does not currently respect separate Anki profiles. If you subscribe to a deck on one profile, then switch to another, it will redownload the fresh deck. A workaround for this is to disable the addon. <code>Tools → Add-ons → Select AnkiCollab → Toggle Enabled</code>
 </details>
 
 <details close>

--- a/faq.md
+++ b/faq.md
@@ -1,9 +1,9 @@
 # Frequently Asked Questions
 
 - [Frequently Asked Questions](#frequently-asked-questions)
-  * [General](#general)
-  * [Subscriber](#subscriber)
-  * [Maintainer](#maintainer)
+  - [General](#general)
+  - [Subscriber](#subscriber)
+  - [Maintainer](#maintainer)
 
 ## General
 

--- a/faq.md
+++ b/faq.md
@@ -1,5 +1,10 @@
 # Frequently Asked Questions
 
+- [Frequently Asked Questions](#frequently-asked-questions)
+  * [General](#general)
+  * [Subscriber](#subscriber)
+  * [Maintainer](#maintainer)
+
 ## General
 
 <details close>

--- a/faq.md
+++ b/faq.md
@@ -8,40 +8,40 @@
 ## General
 
 <details close>
-<summary>Does AnkiCollab handle multiple profiles?</summary>
-AnkiCollab does not currently respect separate Anki profiles. If you subscribe to a deck on one profile, then switch to another, it will redownload the fresh deck. A workaround for this is to disable the addon (Tools → Add-ons → Select AnkiCollab → Toggle Enabled).
+<summary><b>Does AnkiCollab handle multiple profiles?</b></summary>
+AnkiCollab does not currently respect separate Anki profiles. If you subscribe to a deck on one profile, then switch to another, it will redownload the fresh deck. A workaround for this is to disable the addon. <code>Tools → Add-ons → Select AnkiCollab → Toggle Enabled</code>.
 </details>
 
 <details close>
-<summary>Does media get stored on AnkiCollab? How do subscribers get deck media?</summary>
+<summary><b>Does media get stored on AnkiCollab? How do subscribers get deck media?</b></summary>
 AnkiCollab does not upload media (images, audio, etc.) when publishing a deck or suggesting changes. If a deck has media, the maintainer should have a link available for you to download.
 </details>
 
 <details close>
-<summary>How are deck settings handled?</summary>
+<summary><b>How are deck settings handled?</b></summary>
 Deck settings — learning steps, new card limits, maximum interval, etc. — are not uploaded when publishing a deck. When a subscriber downloads a deck, their default deck options are assigned. If you want a subscriber to use specific settings, make a note of them in the deck description.
 </details>
 
 ## Subscriber
 
 <details close>
-<summary>Can I suggest a card to be deleted?</summary>
+<summary><b>Can I suggest a card to be deleted?</b></summary>
 Currently, there is no way to delete individual cards from a deck uploaded to <a href="https://ankicollab.com/decks">AnkiCollab.com/Decks</a>. As a workaround, suggest a tag like <code>#!DELETE</code> indicating that you want a card deleted.
 </details>
 
 ## Maintainer
 
 <details close>
-<summary>How do I delete a deck?</summary>
-There is currently no way to delete decks published to <a href="https://ankicollab.com/decks">AnkiCollab.com/Decks</a>. If you'd like a deck removed, please join our <a href="https://discord.com/invite/9x4DRxzqwM">Discord</a> and let us know! This feature is high on the priority list!
+<summary><b>How do I delete a deck?</b></summary>
+There is currently no way to delete decks published to <a href="https://ankicollab.com/decks">AnkiCollab.com/Decks</a>. If you'd like a deck removed, please join our <a href="https://discord.gg/9x4DRxzqwM">Discord</a> and let us know! This feature is high on the priority list!
 </details>
 
 <details close>
-<summary>How do I make a deck private?</summary>
+<summary><b>How do I make a deck private?</b></summary>
 There is currently no way to upload a deck privately, but you can expect this soon!
 </details>
 
 <details close>
-<summary>How I put a description on the Deck Browser?</summary>
-When you initially publish a deck, the deck description is also uploaded and can be seen on AnkiCollab's deck browser page. If you want to change it, please let us know in our Discord as this is currently a manual process.
+<summary><b>How do I put a description on the Deck Browser page on AnkiCollab?</b></summary>
+When you initially publish a deck, the deck description is also uploaded and can be seen on AnkiCollab's deck browser page. If you want to change it, please let us know in our <a href="https://discord.gg/9x4DRxzqwM">Discord</a> as this is currently a manual process.
 </details>

--- a/getting_started_maintainer.md
+++ b/getting_started_maintainer.md
@@ -70,7 +70,7 @@ Here, the rest of the fields are shown.
 
 ![The full review page on AnkiCollab.com](https://i.imgur.com/Ij62zmY.png)
 
-From here, or the previous page, simply click the ✔️ for suggestions you want to keep or the ❌ to reject them. After that, you're good to go!
+From here, or the previous page, simply click the check mark for suggestions you want to keep or the red X to reject them. After that, you're good to go!
 
 ## Credits
 

--- a/getting_started_maintainer.md
+++ b/getting_started_maintainer.md
@@ -1,5 +1,13 @@
 # Getting Started - Maintainer
 
+- [Getting Started - Maintainer](#getting-started---maintainer)
+  * [Publishing a Deck](#publishing-a-deck)
+    + [Signing Up for AnkiCollab](#signing-up-for-ankicollab)
+    + [Adding a Deck to AnkiCollab](#adding-a-deck-to-ankicollab)
+  * [Handling Suggestions](#handling-suggestions)
+    + [Content Changes — New Cards, Tags, Formatting, etc.](#content-changes---new-cards--tags--formatting--etc)
+  * [Credits](#credits)
+
 Maintainers are the one's keeping AnkiCollab decks healthy, accurate, and updated. When subscribers suggest changes, maintainers approve or reject them.
 
 ## Publishing a Deck

--- a/getting_started_maintainer.md
+++ b/getting_started_maintainer.md
@@ -1,0 +1,59 @@
+# Getting Started - Maintainer
+
+*description*
+
+## Installing the Addon
+
+Before you start, make sure you are using the latest version of Anki found [here](https://apps.ankiweb.net/). If you've never used Anki before, there is a great [Getting Started](https://docs.ankiweb.net/getting-started.html) guide in the Anki manual.
+
+Every add-on in the Anki ecosystem is installed using an **add-on code**. AnkiCollab's code is `1957538407`.
+
+If you ever lose this code, you can always find it on [AnkiCollab add-on page](https://ankiweb.net/shared/info/1957538407). Scroll down a bit and you'll find it in a little box.
+
+![A blue arrow pointing to AnkiCollab's addon code on the Anki Addon page.](https://i.imgur.com/oTlWGHF.png)
+
+Inside of Anki, go Tools → Add-ons → Get Add-ons. From here, a box should pop up where you can enter the code.
+
+![Anki's install add-on window.](https://i.imgur.com/7X6fULn.png)
+
+Click OK and relaunch Anki to finish the installation.
+
+You can confirm that the installation was successful by checking the toolbar for AnkiCollab.
+
+![A blue arrow point at the toolbar of Anki showing an AnkiCollab tab.](https://i.imgur.com/IMHBCXx.png)
+
+## Publishing a Deck
+
+By publishing a deck, you will be the sole maintainer and it will be associated with your email address.
+
+### Signing Up for AnkiCollab
+
+Create an account by going to [AnkiCollab.com/Login](https://www.ankicollab.com/login) and clicking Sign Up Here.
+
+![The sign up page for AnkiCollab website.](https://i.imgur.com/z4I11Wm.png)
+
+### Add Deck to AnkiCollab
+
+Open Anki.
+
+In the toolbar, click AnkiCollab → Publish New Deck.
+
+![A cursor hovering over the Publish New Deck button on the AnkiCollab toolbar tab in Anki.](https://i.imgur.com/jtIWABO.png)
+
+Select the deck you want to upload and enter your email **exactly** as it is on AnkiCollab.com.
+
+![A pop up window from AnkiCollab waiting for the user to choose which deck to publish.](https://i.imgur.com/Q8IaYmu.png)
+
+After clicking Publish Deck, a confirmation message will pop up and you will be able to view your deck on [AnkiCollab.com/Decks](https://www.ankicollab.com/decks).
+
+![A blue arrow pointing to the title of a deck on the AnkiCollab website.](https://i.imgur.com/9NjMnVf.png)
+
+Click on the deck and you can see all the cards as well as the subscription key.
+
+![A blue arrow pointing to the subscription key of a deck on the AnkiCollab website.](https://i.imgur.com/jDP2QuQ.png)
+
+Congratulations! The deck is ready to be shared. All they need is the subscription key — no account required! 👍
+
+## Credits
+
+This guide was written by Andre, and we would like to extend our sincere thanks for his contributions. With his expertise and commitment, this tutorial has become a valuable resource for all those who read it. Thank you, Andre, for your hard work and dedication.

--- a/getting_started_maintainer.md
+++ b/getting_started_maintainer.md
@@ -1,12 +1,12 @@
 # Getting Started - Maintainer
 
 - [Getting Started - Maintainer](#getting-started---maintainer)
-  * [Publishing a Deck](#publishing-a-deck)
-    + [Signing Up for AnkiCollab](#signing-up-for-ankicollab)
-    + [Adding a Deck to AnkiCollab](#adding-a-deck-to-ankicollab)
-  * [Handling Suggestions](#handling-suggestions)
-    + [Content Changes — New Cards, Tags, Formatting, etc.](#content-changes---new-cards--tags--formatting--etc)
-  * [Credits](#credits)
+  - [Publishing a Deck](#publishing-a-deck)
+    - [Signing Up for AnkiCollab](#signing-up-for-ankicollab)
+    - [Adding a Deck to AnkiCollab](#adding-a-deck-to-ankicollab)
+  - [Handling Suggestions](#handling-suggestions)
+    - [Content Changes](#content-changes)
+  - [Credits](#credits)
 
 Maintainers are the one's keeping AnkiCollab decks healthy, accurate, and updated. When subscribers suggest changes, maintainers approve or reject them.
 
@@ -44,7 +44,7 @@ Congratulations! The deck is ready to be shared. All they need is the subscripti
 
 As a maintainer, you are responsible for approving or denying changes. There are multiple types, and we'll cover them all here.
 
-### Content Changes — New Cards, Tags, Formatting, etc.
+### Content Changes
 
 All the different possible changes are handled the same way. Someone (or you) may submit a change — fixing typos, updating content, formatting, or something else. You'll go to the All Reviews page on AnkiCollab and approve or deny them.
 

--- a/getting_started_maintainer.md
+++ b/getting_started_maintainer.md
@@ -8,7 +8,7 @@
     - [Content Changes](#content-changes)
   - [Credits](#credits)
 
-Maintainers are the one's keeping AnkiCollab decks healthy, accurate, and updated. When subscribers suggest changes, maintainers approve or reject them.
+Maintainers are the ones keeping AnkiCollab decks healthy, accurate, and updated. When subscribers suggest changes, maintainers approve or deny them.
 
 ## Publishing a Deck
 
@@ -16,13 +16,13 @@ By publishing a deck, you will be the sole maintainer and it will be associated 
 
 ### Signing Up for AnkiCollab
 
-Create an account by going to [AnkiCollab.com/Login](https://www.ankicollab.com/login) and clicking Sign Up Here.
+Create an account by going to [AnkiCollab.com/Login](https://www.ankicollab.com/login) and clicking **Sign Up Here**.
 
 ![The sign up page for AnkiCollab website.](https://i.imgur.com/z4I11Wm.png)
 
 ### Adding a Deck to AnkiCollab
 
-Inside of Anki, go to the toolbar, and click AnkiCollab → Publish New Deck.
+Inside of Anki, go to the toolbar, and click `AnkiCollab → Publish New Deck`.
 
 ![A cursor hovering over the Publish New Deck button on the AnkiCollab toolbar tab in Anki.](https://i.imgur.com/jtIWABO.png)
 
@@ -30,11 +30,11 @@ Select the deck you want to upload and enter your email **exactly** as it is on 
 
 ![A pop up window from AnkiCollab waiting for the user to choose which deck to publish.](https://i.imgur.com/Q8IaYmu.png)
 
-After clicking Publish Deck, a confirmation message will pop up and you will be able to view your deck on [AnkiCollab.com/Decks](https://www.ankicollab.com/decks).
+After clicking **Publish Deck**, a confirmation message will pop up and you will be able to view your deck on [AnkiCollab.com/Decks](https://www.ankicollab.com/decks).
 
 ![A blue arrow pointing to the title of a deck on the AnkiCollab website.](https://i.imgur.com/9NjMnVf.png)
 
-Click on the deck and you can see all the cards as well as the subscription key.
+Click on the deck and you can see all the cards as well as the **subscription key**. 🔑
 
 ![A blue arrow pointing to the subscription key of a deck on the AnkiCollab website.](https://i.imgur.com/jDP2QuQ.png)
 
@@ -46,15 +46,15 @@ As a maintainer, you are responsible for approving or denying changes. There are
 
 ### Content Changes
 
-All the different possible changes are handled the same way. Someone (or you) may submit a change — fixing typos, updating content, formatting, or something else. You'll go to the All Reviews page on AnkiCollab and approve or deny them.
+All the different possible changes are handled the same way. Someone (or you) may submit a change — fixing typos, updating content, formatting, or something else. You'll go to the **All Reviews** page on AnkiCollab and approve or deny them.
 
 Let's use a sample card from a trivia deck.
 
 ![A flashcard with the front saying "World's Tallest Building" and the back saying "Lotte World Tower."](https://i.imgur.com/JxQGgx5.png)
 
-While Lotte World Tower is definitely tall, it's not the tallest — that would be Burj Khalifa. A good contribute corrects the card and suggests the change.
+While the Lotte World Tower is definitely tall, it's not the tallest — that would be the Burj Khalifa. A good contributor corrects the card and suggests the change.
 
-Navigate to [AnkiCollab.com](https://ankicollab.com/) and click All Reviews to see suggestions for your published decks.
+Navigate to [AnkiCollab.com](https://ankicollab.com/) and click **All Reviews** to see suggestions for your published decks.
 
 ![A blue arrow pointing to All Reviews on AnkiCollab.com](https://i.imgur.com/wTTUTpV.png)
 
@@ -62,7 +62,7 @@ From here, we see we have a suggestion involving a content error.
 
 ![The All Reviews page on AnkiCollab.com](https://i.imgur.com/hWeodp4.png)
 
-When you click on the card, you'll see what the field had before and after the change. If you'd like to see the rest of the fields for context, click Go To Full Review.
+When you click on the card, you'll see what the field had before and after the change. If you'd like to see the rest of the fields for context, click **Go To Full Review**.
 
 ![A blue arrow pointing to the Go To Full Review button.](https://i.imgur.com/hz45hrb.png)
 
@@ -70,7 +70,7 @@ Here, the rest of the fields are shown.
 
 ![The full review page on AnkiCollab.com](https://i.imgur.com/Ij62zmY.png)
 
-From here, or the previous page, simply click the green check mark for suggestions you want to keep or the red X to reject them. After that, you're good to go!
+From here, or the previous page, simply click the ✔️ for suggestions you want to keep or the ❌ to reject them. After that, you're good to go!
 
 ## Credits
 

--- a/getting_started_maintainer.md
+++ b/getting_started_maintainer.md
@@ -1,6 +1,6 @@
 # Getting Started - Maintainer
 
-*description*
+Maintainers are the one's keeping AnkiCollab decks healthy, accurate, and updated. When subscribers suggest changes, maintainers approve or reject them.
 
 ## Publishing a Deck
 
@@ -12,11 +12,9 @@ Create an account by going to [AnkiCollab.com/Login](https://www.ankicollab.com/
 
 ![The sign up page for AnkiCollab website.](https://i.imgur.com/z4I11Wm.png)
 
-### Add Deck to AnkiCollab
+### Adding a Deck to AnkiCollab
 
-Open Anki.
-
-In the toolbar, click AnkiCollab → Publish New Deck.
+Inside of Anki, go to the toolbar, and click AnkiCollab → Publish New Deck.
 
 ![A cursor hovering over the Publish New Deck button on the AnkiCollab toolbar tab in Anki.](https://i.imgur.com/jtIWABO.png)
 
@@ -33,6 +31,38 @@ Click on the deck and you can see all the cards as well as the subscription key.
 ![A blue arrow pointing to the subscription key of a deck on the AnkiCollab website.](https://i.imgur.com/jDP2QuQ.png)
 
 Congratulations! The deck is ready to be shared. All they need is the subscription key — no account required! 👍
+
+## Handling Suggestions
+
+As a maintainer, you are responsible for approving or denying changes. There are multiple types, and we'll cover them all here.
+
+### Content Changes — New Cards, Tags, Formatting, etc.
+
+All the different possible changes are handled the same way. Someone (or you) may submit a change — fixing typos, updating content, formatting, or something else. You'll go to the All Reviews page on AnkiCollab and approve or deny them.
+
+Let's use a sample card from a trivia deck.
+
+![A flashcard with the front saying "World's Tallest Building" and the back saying "Lotte World Tower."](https://i.imgur.com/JxQGgx5.png)
+
+While Lotte World Tower is definitely tall, it's not the tallest — that would be Burj Khalifa. A good contribute corrects the card and suggests the change.
+
+Navigate to [AnkiCollab.com](https://ankicollab.com/) and click All Reviews to see suggestions for your published decks.
+
+![A blue arrow pointing to All Reviews on AnkiCollab.com](https://i.imgur.com/wTTUTpV.png)
+
+From here, we see we have a suggestion involving a content error.
+
+![The All Reviews page on AnkiCollab.com](https://i.imgur.com/hWeodp4.png)
+
+When you click on the card, you'll see what the field had before and after the change. If you'd like to see the rest of the fields for context, click Go To Full Review.
+
+![A blue arrow pointing to the Go To Full Review button.](https://i.imgur.com/hz45hrb.png)
+
+Here, the rest of the fields are shown.
+
+![The full review page on AnkiCollab.com](https://i.imgur.com/Ij62zmY.png)
+
+From here, or the previous page, simply click the green check mark for suggestions you want to keep or the red X to reject them. After that, you're good to go!
 
 ## Credits
 

--- a/getting_started_maintainer.md
+++ b/getting_started_maintainer.md
@@ -2,26 +2,6 @@
 
 *description*
 
-## Installing the Addon
-
-Before you start, make sure you are using the latest version of Anki found [here](https://apps.ankiweb.net/). If you've never used Anki before, there is a great [Getting Started](https://docs.ankiweb.net/getting-started.html) guide in the Anki manual.
-
-Every add-on in the Anki ecosystem is installed using an **add-on code**. AnkiCollab's code is `1957538407`.
-
-If you ever lose this code, you can always find it on [AnkiCollab add-on page](https://ankiweb.net/shared/info/1957538407). Scroll down a bit and you'll find it in a little box.
-
-![A blue arrow pointing to AnkiCollab's addon code on the Anki Addon page.](https://i.imgur.com/oTlWGHF.png)
-
-Inside of Anki, go Tools → Add-ons → Get Add-ons. From here, a box should pop up where you can enter the code.
-
-![Anki's install add-on window.](https://i.imgur.com/7X6fULn.png)
-
-Click OK and relaunch Anki to finish the installation.
-
-You can confirm that the installation was successful by checking the toolbar for AnkiCollab.
-
-![A blue arrow point at the toolbar of Anki showing an AnkiCollab tab.](https://i.imgur.com/IMHBCXx.png)
-
 ## Publishing a Deck
 
 By publishing a deck, you will be the sole maintainer and it will be associated with your email address.

--- a/getting_started_subscriber.md
+++ b/getting_started_subscriber.md
@@ -1,5 +1,13 @@
 # Getting Started - Subscriber
 
+- [Getting Started - Subscriber](#getting-started---subscriber)
+  * [Getting a Key](#getting-a-key)
+  * [Adding the Key to Anki](#adding-the-key-to-anki)
+  * [Suggesting Changes](#suggesting-changes)
+    + [Card Content and Tags](#card-content-and-tags)
+    + [New Cards](#new-cards)
+
+
 If you don't want to maintain or publish decks, you **do not** need an account. All you need is the deck's **subscription key**.
 
 The key will be a series of words separated by dashes. Example:
@@ -46,7 +54,7 @@ If you see the title of the deck pop up, you are ready to start reviewing! 👍
 
 ## Suggesting Changes
 
-### Editing Card Content and Tags
+### Card Content and Tags
 
 Not every Anki deck is perfect — typos, content errors, strange formatting, or other issues might crop up. There might even be some errors in this very document that will get changed in the future!
 
@@ -58,7 +66,7 @@ Let's say you subscribe to a deck and find this card:
 
 ![An Anki card in the editor. The front reads "Biggest Animal in the World" and the back reads "Elephant."](https://i.imgur.com/wbKuRPj.png)
 
-Sure, elephants are big, but you *know* the biggest animal in the world is *actually* a Blue Whale.
+Sure, elephants are big, but you *know* that the biggest animal in the world is *actually* a Blue Whale.
 
 After double-checking that you're correct, change the word Elephant to Blue Whale in the same manner you would edit a normal card.
 
@@ -80,7 +88,7 @@ From the maintainer's point of view, they'll see a window like this:
 
 This page tells the maintainer what exactly was changed and why.
 
-From here, they can approve or reject your suggestion. If approved, everyone subscribed to this deck will receive an update with your change.
+From here, they can approve or reject your suggestion. If approved, everyone who subscribed to this deck will receive an update with your change.
 
 You are now ready to go into the AnkiCollab world and improve decks! 👍
 

--- a/getting_started_subscriber.md
+++ b/getting_started_subscriber.md
@@ -8,7 +8,7 @@ The key will be a series of words separated by dashes. Example:
 pip-item-hawaii-skylark-network-rugby
 ```
 
-### Getting a Key
+## Getting a Key
 
 If you know a deck's maintainer, they can give you the subscription key to paste into AnkiCollab.
 If you know the deck's name, but don't know the key, go to [AnkiCollab.com/Decks](https://www.ankicollab.com/decks).
@@ -20,7 +20,7 @@ Click on the deck and the subscription key will be on the top. Copy it.
 
 ![A blue arrow point to a subscription key on the AnkiCollab website.](https://i.imgur.com/wx50dDa.png)
 
-### Adding the Key to Anki
+## Adding the Key to Anki
 
 Open Anki.
 
@@ -44,13 +44,15 @@ The deck may not show up immediately! If you don't see the deck, click the Deck 
 
 If you see the title of the deck pop up, you are ready to start reviewing! 👍
 
-## Suggesting a Change
+## Suggesting Changes
 
-### Editing Card Content
+### Editing Card Content and Tags
 
-Not every Anki deck will be perfect — some might have typos, content errors, strange formatting, or other issues. There might even be some errors in this very document that will get changed in the future!
+Not every Anki deck is perfect — typos, content errors, strange formatting, or other issues might crop up. There might even be some errors in this very document that will get changed in the future!
 
 One huge strength of AnkiCollab is the ability to let the maintainer know that there might be an issue with a deck.
+
+⚠ In this section, we'll be showing how to change a card's content within the fields, but the process is **identical** for tags.
 
 Let's say you subscribe to a deck and find this card:
 
@@ -81,3 +83,15 @@ This page tells the maintainer what exactly was changed and why.
 From here, they can approve or reject your suggestion. If approved, everyone subscribed to this deck will receive an update with your change.
 
 You are now ready to go into the AnkiCollab world and improve decks! 👍
+
+### New Cards
+
+Some decks on AnkiCollab are unfinished, looking for people to contribute and finish them. In this case, you don't want to be *editing* cards, but *adding* new ones.
+
+⚠️ Before you start adding cards, make sure you are adding them to the correct deck!
+
+Let's say you subscribed to a Flower Identification deck, but they're missing the California Poppy. When adding the card, all you have to do is check the Suggest on AnkiCollab button toward the bottom.
+
+![Blue arrow pointing to the Suggest on AnkiCollab buttom at the bottom of the Add window.](https://i.imgur.com/HvJM2Fn.png)
+
+Now you just need to wait for the maintainer to approve your card!

--- a/getting_started_subscriber.md
+++ b/getting_started_subscriber.md
@@ -77,7 +77,7 @@ A small window will pop up and ask you to choose a rationale for making this cha
 
 ![A small pop up window with a dropdown box of various reasons for suggesting a change.](https://i.imgur.com/OhLwRH4.png)
 
-In our case, let's choose **Content Error**. Next, click 🆗.
+In our case, let's choose **Content Error**. Next, click **OK**.
 
 You've now submitted your first change!
 

--- a/getting_started_subscriber.md
+++ b/getting_started_subscriber.md
@@ -1,12 +1,11 @@
 # Getting Started - Subscriber
 
 - [Getting Started - Subscriber](#getting-started---subscriber)
-  * [Getting a Key](#getting-a-key)
-  * [Adding the Key to Anki](#adding-the-key-to-anki)
-  * [Suggesting Changes](#suggesting-changes)
-    + [Card Content and Tags](#card-content-and-tags)
-    + [New Cards](#new-cards)
-
+  - [Getting a Key](#getting-a-key)
+  - [Adding the Key to Anki](#adding-the-key-to-anki)
+  - [Suggesting Changes](#suggesting-changes)
+    - [Card Content and Tags](#card-content-and-tags)
+    - [New Cards](#new-cards)
 
 If you don't want to maintain or publish decks, you **do not** need an account. All you need is the deck's **subscription key**.
 

--- a/getting_started_subscriber.md
+++ b/getting_started_subscriber.md
@@ -1,30 +1,4 @@
-# Getting Started
-
-## Description
-
-AnkiCollab is an open-source, free, collaboration tool to create and share Anki decks. If you ever wanted to split up the work of making cards, AnkiCollab offers a platform to make this possible.
-
-## Installing the Addon
-
-Before you start, make sure you are using the latest version of Anki found [here](https://apps.ankiweb.net/). If you've never used Anki before, there is a great [Getting Started](https://docs.ankiweb.net/getting-started.html) guide in the Anki manual.
-
-Every add-on in the Anki ecosystem is installed using an **add-on code**. AnkiCollab's code is `1957538407`.
-
-If you ever lose this code, you can always find it on [AnkiCollab add-on page](https://ankiweb.net/shared/info/1957538407). Scroll down a bit and you'll find it in a little box.
-
-![A blue arrow pointing to AnkiCollab's addon code on the Anki Addon page.](https://i.imgur.com/oTlWGHF.png)
-
-Inside of Anki, go Tools → Add-ons → Get Add-ons. From here, a box should pop up where you can enter the code.
-
-![Anki's install add-on window.](https://i.imgur.com/7X6fULn.png)
-
-Click OK and relaunch Anki to finish the installation.
-
-You can confirm that the installation was successful by checking the toolbar for AnkiCollab.
-
-![A blue arrow point at the toolbar of Anki showing an AnkiCollab tab.](https://i.imgur.com/IMHBCXx.png)
-
-## Subscribing to a Deck
+# Getting Started - Subscriber
 
 If you don't want to maintain or publish decks, you **do not** need an account. All you need is the deck's **subscription key**.
 
@@ -70,39 +44,9 @@ The deck may not show up immediately! If you don't see the deck, click the Deck 
 
 If you see the title of the deck pop up, you are ready to start reviewing! 👍
 
-## Publishing a Deck
-
-By publishing a deck, you will be the sole maintainer and it will be associated with your email address.
-
-### Signing Up for AnkiCollab
-
-Create an account by going to [AnkiCollab.com/Login](https://www.ankicollab.com/login) and clicking Sign Up Here.
-
-![The sign up page for AnkiCollab website.](https://i.imgur.com/z4I11Wm.png)
-
-### Add Deck to AnkiCollab
-
-Open Anki.
-
-In the toolbar, click AnkiCollab → Publish New Deck.
-
-![A cursor hovering over the Publish New Deck button on the AnkiCollab toolbar tab in Anki.](https://i.imgur.com/jtIWABO.png)
-
-Select the deck you want to upload and enter your email **exactly** as it is on AnkiCollab.com.
-
-![A pop up window from AnkiCollab waiting for the user to choose which deck to publish.](https://i.imgur.com/Q8IaYmu.png)
-
-After clicking Publish Deck, a confirmation message will pop up and you will be able to view your deck on [AnkiCollab.com/Decks](https://www.ankicollab.com/decks).
-
-![A blue arrow pointing to the title of a deck on the AnkiCollab website.](https://i.imgur.com/9NjMnVf.png)
-
-Click on the deck and you can see all the cards as well as the subscription key.
-
-![A blue arrow pointing to the subscription key of a deck on the AnkiCollab website.](https://i.imgur.com/jDP2QuQ.png)
-
-Congratulations! The deck is ready to be shared. All they need is the subscription key — no account required! 👍
-
 ## Suggesting a Change
+
+### Editing Card Content
 
 Not every Anki deck will be perfect — some might have typos, content errors, strange formatting, or other issues. There might even be some errors in this very document that will get changed in the future!
 
@@ -137,7 +81,3 @@ This page tells the maintainer what exactly was changed and why.
 From here, they can approve or reject your suggestion. If approved, everyone subscribed to this deck will receive an update with your change.
 
 You are now ready to go into the AnkiCollab world and improve decks! 👍
-
-## Credits
-
-This guide was written by Andre, and we would like to extend our sincere thanks for his contributions. With his expertise and commitment, this tutorial has become a valuable resource for all those who read it. Thank you, Andre, for your hard work and dedication.

--- a/getting_started_subscriber.md
+++ b/getting_started_subscriber.md
@@ -7,7 +7,7 @@
     - [Card Content and Tags](#card-content-and-tags)
     - [New Cards](#new-cards)
 
-If you don't want to maintain or publish decks, you **do not** need an account. All you need is the deck's **subscription key**.
+If you don't want to maintain or publish decks, you **do not** need an account. The **subscription key** 🔑 is all you need!
 
 The key will be a series of words separated by dashes. Example:
 
@@ -23,7 +23,7 @@ On the right, you'll find a search box to help locate the deck.
 
 ![A blue arrow pointing a search box on the AnkiCollab website.](https://i.imgur.com/RJnAdEU.png)
 
-Click on the deck and the subscription key will be on the top. Copy it.
+Click on the deck and the subscription key will be on the top in blue. Copy it.
 
 ![A blue arrow point to a subscription key on the AnkiCollab website.](https://i.imgur.com/wx50dDa.png)
 
@@ -31,7 +31,7 @@ Click on the deck and the subscription key will be on the top. Copy it.
 
 Open Anki.
 
-On the toolbar, click AnkiCollab → Edit Subscriptions.
+On the toolbar, click `AnkiCollab → Edit Subscriptions`.
 
 ![A cursor hovering over the Edit Subscriptions button on the AnkiCollab toolbar tab in Anki.](https://i.imgur.com/vC4fI5n.png)
 
@@ -39,13 +39,13 @@ This window will show all your current subscriptions.
 
 ![AnkiCollab's subscription window showing currently subscribed decks.](https://i.imgur.com/srz5ENz.png)
 
-Add a new deck by pasting it into the box at the bottom and clicking Add Subscription.
+Add a new deck by pasting it into the box at the bottom and clicking **Add Subscription**.
 
 ![In the same window, with a new subscription key added.](https://i.imgur.com/gpBov9f.png)
 
 There will be a confirmation and you can now close this window.
 
-The deck may not show up immediately! If you don't see the deck, click the Deck button at the top of the main Anki page to refresh the view.
+The deck may not show up immediately! If you don't see the deck, click the Deck button at the top of the main Anki page to refresh 🔄 the view.
 
 ![An arrow pointing to the "deck" button on the main page of Anki.](https://i.imgur.com/c5S0VrZ.png)
 
@@ -55,7 +55,7 @@ If you see the title of the deck pop up, you are ready to start reviewing! 👍
 
 ### Card Content and Tags
 
-Not every Anki deck is perfect — typos, content errors, strange formatting, or other issues might crop up. There might even be some errors in this very document that will get changed in the future!
+Not every Anki deck is perfect — typos, content errors, strange formatting, or other issues might pop up. There might even be some errors in this very document that will get changed in the future!
 
 One huge strength of AnkiCollab is the ability to let the maintainer know that there might be an issue with a deck.
 
@@ -65,7 +65,7 @@ Let's say you subscribe to a deck and find this card:
 
 ![An Anki card in the editor. The front reads "Biggest Animal in the World" and the back reads "Elephant."](https://i.imgur.com/wbKuRPj.png)
 
-Sure, elephants are big, but you *know* that the biggest animal in the world is *actually* a Blue Whale.
+Sure, elephants 🐘 are big, but you *know* that the biggest animal in the world is *actually* a Blue Whale 🐳.
 
 After double-checking that you're correct, change the word Elephant to Blue Whale in the same manner you would edit a normal card.
 
@@ -77,7 +77,7 @@ A small window will pop up and ask you to choose a rationale for making this cha
 
 ![A small pop up window with a dropdown box of various reasons for suggesting a change.](https://i.imgur.com/OhLwRH4.png)
 
-In our case, let's choose Content Error. Next, click OK.
+In our case, let's choose **Content Error**. Next, click 🆗.
 
 You've now submitted your first change!
 


### PR DESCRIPTION
Split the Getting Started Guides into 2 separate pages — Getting Started for maintainers and subscribers. FAQ was created with a few basic questions. I'll add more later.

I put an intro and installation guide on the README so it is the first thing people see to make things super clear. The README also links to the two guides, FAQ, and essential links like Discord.