### PR TITLE
Change settings menu back to NoRole

### DIFF
--- a/plugin_source/menu.py
+++ b/plugin_source/menu.py
@@ -20,11 +20,11 @@ collab_menu = QMenu('AnkiCollab', mw)
 settings_menu = QMenu('Settings', mw)
 
 # Prevent macOS menu bar merging into Preferences by string matching "settings"
-# by setting MenuRole to ApplicationSpecificRole from the default TextHeuristicRole.
-settings_menu.menuAction().setMenuRole(QAction.ApplicationSpecificRole)
+# by setting MenuRole to NoRole from the default TextHeuristicRole.
+settings_menu.menuAction().setMenuRole(QAction.NoRole)
 # Also set this for the settings menu actions to be safe.
-pull_on_startup_action.setMenuRole(QAction.ApplicationSpecificRole)
-auto_approve_action.setMenuRole(QAction.ApplicationSpecificRole)
+pull_on_startup_action.setMenuRole(QAction.NoRole)
+auto_approve_action.setMenuRole(QAction.NoRole)
 
 def add_maintainer_checkbox():
     strings_data = mw.addonManager.getConfig(__name__)


### PR DESCRIPTION
Related to https://github.com/CravingCrates/AnkiCollab-Plugin/pull/19, I think NoRole is a safer choice than the ApplicationSpecificRole. This is what I set originally and second guessed it and now I'm thinking this is the right role just based off this:

> You can override this behavior by setting the [QAction::menuRole](https://doc.qt.io/qt-6/qaction.html#menuRole-prop)() property to [QAction::NoRole](https://doc.qt.io/qt-6/qaction.html#MenuRole-enum).