### PR TITLE
Feat/add push all review history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vscode/
 plugin_source/dist/
 __pycache__/
+plugin_source/meta.json
+.idea/

--- a/plugin_source/dialogs.py
+++ b/plugin_source/dialogs.py
@@ -265,13 +265,13 @@ class DeletedNotesDialog(QDialog):
         self.adjustSize()
         
 class AskShareStatsDialog(QDialog):
-    def __init__(self, parent=None):
+    def __init__(self, deck_name, parent=None):
         super().__init__(parent)
         self.setWindowTitle("Help Improve the Deck!")
 
         self.layout = QVBoxLayout(self)
-
-        self.message = QLabel("The deck maintainers would like to use anonymized review data to improve the deck. Would you like to share your stats?")
+        self.deck_name = deck_name
+        self.message = QLabel(f"The maintainers of '{self.deck_name}' would like to use anonymized review data to improve the deck. Would you like to share your stats?")
         self.layout.addWidget(self.message)
 
         self.checkbox = QCheckBox("Remember my decision")

--- a/plugin_source/import_manager.py
+++ b/plugin_source/import_manager.py
@@ -34,11 +34,8 @@ def do_nothing(count: int):
     pass
 
 
-def on_stats_upload_done(show_tooltip: bool = False) -> None:
+def on_stats_upload_done(data) -> None:
     mw.progress.finish()
-
-    if show_tooltip:
-        aqt.utils.tooltip("Review History upload done. Thanks for sharing!", parent=mw.focusWidget())
 
 
 def update_optional_tag_config(given_deck_hash, optional_tags):
@@ -264,7 +261,6 @@ def ask_for_rating():
 
 
 def import_webresult(webresult, input_hash, silent=False):
-    print(webresult)
     # if webresult is empty, tell user that there are no updates
     if not webresult:
         if silent:
@@ -281,13 +277,13 @@ def import_webresult(webresult, input_hash, silent=False):
     # Create backup before doing anything
     create_backup(background=True)  # run in background
 
-    for subscription in webresult:
-        if input_hash:  # New deck
-            deck_name = install_update(subscription)
-            with DeckConfigManager() as decks:
+    with DeckConfigManager() as decks:
+        for subscription in webresult:
+            if input_hash:  # New deck
+                deck_name = install_update(subscription)
                 for deck_hash, details in decks:
                     if (
-                            hash == input_hash and details["deckId"] == 0
+                            deck_hash == input_hash and details["deckId"] == 0
                     ):  # should only be the case once when they add a new subscription and never ambiguous
                         details["deckId"] = aqt.mw.col.decks.id(deck_name)
                         # large decks use cached data that may be a day old, so we need to update the timestamp to force a refresh
@@ -304,7 +300,6 @@ def import_webresult(webresult, input_hash, silent=False):
         aqt.mw.taskman.run_on_main(
             lambda: aqt.utils.tooltip(info, parent=mw)
         )
-
     update_stats()
 
 

--- a/plugin_source/import_manager.py
+++ b/plugin_source/import_manager.py
@@ -1,21 +1,13 @@
 from collections import defaultdict
-from dataclasses import dataclass, field
-from enum import Enum
 import json
-import os
-import webbrowser
+
 import requests
 from datetime import datetime, timedelta, timezone
-from concurrent.futures import Future
-
-from pprint import pp
-from typing import List
 
 import aqt
 import aqt.utils
 from aqt.operations import QueryOp
-import anki
-from anki.utils import point_version
+
 from aqt.qt import *
 from aqt import mw
 
@@ -23,56 +15,47 @@ from .var_defs import API_BASE_URL
 
 from .dialogs import ChangelogDialog, DeletedNotesDialog, OptionalTagsDialog, AskShareStatsDialog, RateAddonDialog
 
-from .crowd_anki.anki.adapters.note_model_file_provider import NoteModelFileProvider
-from .crowd_anki.representation.note import Note
-from .crowd_anki.config.config_settings import ConfigSettings
-from .crowd_anki.export.note_sorter import NoteSorter
-from .crowd_anki.utils.disambiguate_uuids import disambiguate_note_model_uuids
-
-from .crowd_anki.representation import *
 from .crowd_anki.representation import deck_initializer
-from .crowd_anki.anki.adapters.anki_deck import AnkiDeck
-from .crowd_anki.representation.deck import Deck
 from .crowd_anki.importer.import_dialog import ImportConfig
 
-from .utils import create_backup, get_deck_hash_from_did
+from .utils import create_backup, get_local_deck_from_id, DeckConfigManager
 
 from .stats import ReviewHistory
-
-from . import main
 
 import base64
 import gzip
 
-from .thread import run_function_in_thread, run_async_function_in_thread, sync_run_async
 import logging
+
 logger = logging.getLogger("ankicollab")
+
 
 def do_nothing(count: int):
     pass
 
-def on_stats_upload_done(data) -> None:
+
+def on_stats_upload_done(show_tooltip: bool = False) -> None:
     mw.progress.finish()
-    #aqt.utils.tooltip("Review History upload done. Thanks for sharing!", parent=QApplication.focusWidget())
-     
-def update_optional_tag_config(deck_hash, optional_tags):
-    strings_data = mw.addonManager.getConfig(__name__)
-    if strings_data:
-        for hash, details in strings_data.items():
-            if hash == deck_hash:
-                details["optional_tags"] = optional_tags
-    mw.addonManager.writeConfig(__name__, strings_data)
+
+    if show_tooltip:
+        aqt.utils.tooltip("Review History upload done. Thanks for sharing!", parent=mw.focusWidget())
 
 
-def get_optional_tags(deck_hash):
-    strings_data = mw.addonManager.getConfig(__name__)
-    if strings_data:
-        for hash, details in strings_data.items():
-            if hash == deck_hash:
-                if "optional_tags" not in details:
-                    return {}
-                return details["optional_tags"]
-    return {}
+def update_optional_tag_config(given_deck_hash, optional_tags):
+    with DeckConfigManager() as decks:
+        details = decks.get_by_hash(given_deck_hash)
+        if details:
+            details["optional_tags"] = optional_tags
+
+
+def get_optional_tags(given_deck_hash) -> dict:
+    with DeckConfigManager() as decks:
+        details = decks.get_by_hash(given_deck_hash)
+        if details is None:
+            return {}
+
+        return details.get("optional_tags", {})
+
 
 def check_optional_tag_changes(deck_hash, optional_tags):
     sorted_old = sorted(get_optional_tags(deck_hash).keys())
@@ -80,14 +63,11 @@ def check_optional_tag_changes(deck_hash, optional_tags):
     return sorted_old != sorted_new
 
 
-def update_timestamp(deck_hash):
-    strings_data = mw.addonManager.getConfig(__name__)
-    if strings_data:
-        for sub, details in strings_data.items():
-            if sub == deck_hash:
-                details["timestamp"] = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
-                break
-        mw.addonManager.writeConfig(__name__, strings_data)
+def update_timestamp(given_deck_hash):
+    with DeckConfigManager() as decks:
+        details = decks.get_by_hash(given_deck_hash)
+        if details:
+            details["timestamp"] = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
 
 
 def get_noteids_from_uuids(guids):
@@ -119,107 +99,100 @@ def open_browser_with_nids(nids):
     )
     browser.onSearchActivated()
 
+
 def delete_notes(nids):
     if not nids:
         return
     aqt.mw.col.remove_notes(nids)
-    aqt.mw.col.reset() # deprecated
+    aqt.mw.col.reset()  # deprecated
     mw.reset()
     aqt.mw.taskman.run_on_main(
         lambda: aqt.utils.tooltip(
             "Deleted %d notes." % len(nids), parent=QApplication.focusWidget()
         )
     )
-    
-def update_stats_timestamp(deck_hash):
-    strings_data = mw.addonManager.getConfig(__name__)
-    if strings_data:
-        for sub, details in strings_data.items():
-            if sub == deck_hash:
-                details["last_stats_timestamp"] = int(datetime.now(timezone.utc).timestamp())
-                break
-        mw.addonManager.writeConfig(__name__, strings_data)
-        
-def wants_to_share_stats(deck_hash):
-    strings_data = mw.addonManager.getConfig(__name__)
-    stats_enabled = False
-    last_stats_timestamp = 0
-    if strings_data:
-        for sub, details in strings_data.items():
-            if sub == deck_hash:
-                if "last_stats_timestamp" in details:
-                    last_stats_timestamp = details["last_stats_timestamp"]                
-                if "share_stats" in details:
-                    stats_enabled = details["share_stats"]
-                else:
-                    dialog = AskShareStatsDialog()
-                    choice = dialog.exec()
-                    if choice == QDialog.DialogCode.Accepted:
-                        stats_enabled = True
-                    else:
-                        stats_enabled = False
-                    if dialog.isChecked():
-                        details["share_stats"] = stats_enabled                    
-                        mw.addonManager.writeConfig(__name__, strings_data)
-                break
-    return (stats_enabled, last_stats_timestamp)
 
-def install_update(subscription, is_new = False):
-    deckHash = subscription["deck_hash"]
+
+def update_stats() -> None:
+    with DeckConfigManager() as decks:
+        for deck_hash, details in decks:
+            if details['stats_enabled']:
+                # Only upload stats if the user wants to share them
+                (share_data, last_stats_timestamp) = wants_to_share_stats(details)
+                if share_data:
+                    rh = ReviewHistory(deck_hash)
+                    op = QueryOp(
+                        parent=mw,
+                        op=lambda _: rh.upload_review_history(last_stats_timestamp),
+                        success=on_stats_upload_done
+                    )
+                    op.with_progress(
+                        "Uploading Review History..."
+                    ).run_in_background()
+                    update_stats_timestamp(details)
+
+
+def update_stats_timestamp(details) -> None:
+    details["last_stats_timestamp"] = int(datetime.now(timezone.utc).timestamp())
+
+
+def wants_to_share_stats(details) -> (bool, int):
+    last_stats_timestamp = details.get("last_stats_timestamp", 0)
+    stats_enabled = details.get("share_stats")
+
+    if stats_enabled is None:
+        deck = get_local_deck_from_id(details["deckId"])
+        dialog = AskShareStatsDialog(deck)
+        choice = dialog.exec()
+        if choice == QDialog.DialogCode.Accepted:
+            stats_enabled = True
+        else:
+            stats_enabled = False
+        if dialog.isChecked():
+            details["share_stats"] = stats_enabled
+
+    return stats_enabled, last_stats_timestamp
+
+
+def install_update(subscription):
+    deck_hash = subscription["deck_hash"]
     if check_optional_tag_changes(
-        deckHash, subscription["optional_tags"]
+            deck_hash, subscription["optional_tags"]
     ):
         dialog = OptionalTagsDialog(
-            get_optional_tags(deckHash), subscription["optional_tags"]
+            get_optional_tags(deck_hash), subscription["optional_tags"]
         )
         dialog.exec()
         update_optional_tag_config(
-            deckHash, dialog.get_selected_tags()
+            deck_hash, dialog.get_selected_tags()
         )
-    subscribed_tags = get_optional_tags(deckHash)
-
-    stats_enabled = subscription["stats_enabled"]
+    subscribed_tags = get_optional_tags(deck_hash)
 
     deck = deck_initializer.from_json(subscription["deck"])
     config = prep_config(
         subscription["protected_fields"],
         [tag for tag, value in subscribed_tags.items() if value],
         True if subscription["optional_tags"] else False,
-        deckHash
+        deck_hash
     )
-    config.home_deck = get_home_deck(deckHash)
-        
+    config.home_deck = get_home_deck(deck_hash)
+
     map_cache = defaultdict(dict)
     note_type_data = {}
     deck.handle_notetype_changes(aqt.mw.col, map_cache, note_type_data)
     deck.save_to_collection(aqt.mw.col, map_cache, note_type_data, import_config=config)
-    
+
     # Handle deleted Notes
     deleted_nids = get_noteids_from_uuids(subscription["deleted_notes"])
     if deleted_nids:
-        del_notes_dialog = DeletedNotesDialog(deleted_nids, deckHash)
+        del_notes_dialog = DeletedNotesDialog(deleted_nids, deck_hash)
         del_notes_choice = del_notes_dialog.exec()
 
         if del_notes_choice == QDialog.DialogCode.Accepted:
             delete_notes(deleted_nids)
         elif del_notes_choice == QDialog.DialogCode.Rejected:
             open_browser_with_nids(deleted_nids)
-    # Upload stats if the maintainer wants them, don't bother for new decks
-    if stats_enabled and not is_new:
-        # Only upload stats if the user wants to share them
-        (share_data, last_stats_timestamp) = wants_to_share_stats(deckHash)
-        if share_data:
-            rh = ReviewHistory(deckHash)
-            op = QueryOp(
-                parent=mw,
-                op=lambda _: rh.upload_review_history(last_stats_timestamp),
-                success=on_stats_upload_done
-            )
-            op.with_progress(
-                "Uploading Review History..."
-            ).run_in_background()
-            update_stats_timestamp(deckHash)
-        
+
     return deck.anki_dict["name"]
 
 
@@ -267,9 +240,10 @@ def show_changelog_popup(subscription):
             postpone_update()
         else:
             abort_update(deck_hash)
-    else: # Skip changelog window if there is no message for the user
+    else:  # Skip changelog window if there is no message for the user
         install_update(subscription)
         update_timestamp(deck_hash)
+
 
 def ask_for_rating():
     strings_data = mw.addonManager.getConfig(__name__)
@@ -277,18 +251,20 @@ def ask_for_rating():
         if "pull_counter" in strings_data["settings"]:
             pull_counter = strings_data["settings"]["pull_counter"]
             strings_data["settings"]["pull_counter"] = pull_counter + 1
-            if pull_counter % 30 == 0: # every 30 pulls
-                last_ratepls = strings_data["settings"]["last_ratepls"]                
+            if pull_counter % 30 == 0:  # every 30 pulls
+                last_ratepls = strings_data["settings"]["last_ratepls"]
                 last_ratepls_dt = datetime.strptime(last_ratepls, '%Y-%m-%d %H:%M:%S').replace(tzinfo=timezone.utc)
                 if (datetime.now(timezone.utc) - last_ratepls_dt).days > 30:
-                    if not strings_data["settings"]["rated_addon"]: # only ask if they haven't rated the addon yet
-                        strings_data["settings"]["last_ratepls"] = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+                    if not strings_data["settings"]["rated_addon"]:  # only ask if they haven't rated the addon yet
+                        strings_data["settings"]["last_ratepls"] = datetime.now(timezone.utc).strftime(
+                            '%Y-%m-%d %H:%M:%S')
                         dialog = RateAddonDialog()
                         dialog.exec()
             mw.addonManager.writeConfig(__name__, strings_data)
 
 
 def import_webresult(webresult, input_hash, silent=False):
+    print(webresult)
     # if webresult is empty, tell user that there are no updates
     if not webresult:
         if silent:
@@ -298,35 +274,39 @@ def import_webresult(webresult, input_hash, silent=False):
             msg_box.setWindowTitle("AnkiCollab")
             msg_box.setText("You're already up-to-date!")
             msg_box.exec()
+
+        update_stats()
         return
-    
+
     # Create backup before doing anything
-    create_backup(background=True) # run in background
+    create_backup(background=True)  # run in background
 
     for subscription in webresult:
         if input_hash:  # New deck
-            deck_name = install_update(subscription, True)
-            strings_data = mw.addonManager.getConfig(__name__)
-            for hash, details in strings_data.items():
-                if (
-                    hash == input_hash and details["deckId"] == 0
-                ):  # should only be the case once when they add a new subscription and never ambiguous
-                    details["deckId"] = aqt.mw.col.decks.id(deck_name)
-                    # large decks use cached data that may be a day old, so we need to update the timestamp to force a refresh
-                    details["timestamp"] = (
-                        datetime.now(timezone.utc) - timedelta(days=1)
-                    ).strftime("%Y-%m-%d %H:%M:%S")
-
-            mw.addonManager.writeConfig(__name__, strings_data)
+            deck_name = install_update(subscription)
+            with DeckConfigManager() as decks:
+                for deck_hash, details in decks:
+                    if (
+                            hash == input_hash and details["deckId"] == 0
+                    ):  # should only be the case once when they add a new subscription and never ambiguous
+                        details["deckId"] = aqt.mw.col.decks.id(deck_name)
+                        # large decks use cached data that may be a day old, so we need to update the timestamp to force a refresh
+                        details["timestamp"] = (
+                                datetime.now(timezone.utc) - timedelta(days=1)
+                        ).strftime("%Y-%m-%d %H:%M:%S")
+                        details["stats_enabled"] = subscription["stats_enabled"]
         else:  # Update deck
             show_changelog_popup(subscription)
-    
-    if not input_hash: # Only ask for a rating if they are updating a deck and not adding a new deck to avoid spam popups
+
+    if not input_hash:  # Only ask for a rating if they are updating a deck and not adding a new deck to avoid spam popups
         ask_for_rating()
-        infot = "AnkiCollab: Updated deck(s) successfully!"
+        info = "AnkiCollab: Updated deck(s) successfully!"
         aqt.mw.taskman.run_on_main(
-            lambda: aqt.utils.tooltip(infot, parent=mw)
+            lambda: aqt.utils.tooltip(info, parent=mw)
         )
+
+    update_stats()
+
 
 def get_card_suspension_status():
     strings_data = mw.addonManager.getConfig(__name__)
@@ -335,6 +315,7 @@ def get_card_suspension_status():
         val = bool(strings_data["settings"]["suspend_new_cards"])
     return val
 
+
 def get_deck_movement_status():
     strings_data = mw.addonManager.getConfig(__name__)
     val = True
@@ -342,12 +323,14 @@ def get_deck_movement_status():
         val = bool(strings_data["settings"]["auto_move_cards"])
     return val
 
-def get_home_deck(deck_hash):
-    strings_data = mw.addonManager.getConfig(__name__)
-    for hash, details in strings_data.items():
-        if (hash == deck_hash and details["deckId"] != 0):  # Local Deck is set
+
+def get_home_deck(given_deck_hash):
+    with DeckConfigManager() as decks:
+        details = decks.get_by_hash(given_deck_hash)
+
+        if details and details["deckId"] != 0:
             return mw.col.decks.name_if_exists(details["deckId"])
-    return None
+
 
 def remove_nonexistent_decks():
     strings_data = mw.addonManager.getConfig(__name__)
@@ -355,14 +338,14 @@ def remove_nonexistent_decks():
     if strings_data is not None and len(strings_data) > 0:
         # Create a copy of the config data
         strings_data_copy = strings_data.copy()
-        
+
         # backwards compatibility
         if "settings" in strings_data_copy:
             del strings_data_copy["settings"]
-        
+
         if "auth" in strings_data_copy:
             del strings_data_copy["auth"]
-        
+
         # Only include the specific hash if it exists
         strings_data_to_send = strings_data_copy
 
@@ -388,28 +371,29 @@ def remove_nonexistent_decks():
                 else:
                     print("strings_data is None or empty")
 
+
 # Kinda ugly, but for backwards compatibility we need to handle both the old and new format
 def handle_pull(input_hash, silent=False):
     strings_data = mw.addonManager.getConfig(__name__)
     if strings_data is not None and len(strings_data) > 0:
         # Create a copy of the config data
         strings_data_copy = strings_data.copy()
-        
+
         # backwards compatibility
         if "settings" in strings_data_copy:
             del strings_data_copy["settings"]
-        
+
         if "auth" in strings_data_copy:
             del strings_data_copy["auth"]
-        
+
         # Create the data to send based on whether input_hash is provided
         if input_hash is None:
             strings_data_to_send = strings_data_copy
         else:
             # Only include the specific hash if it exists
             strings_data_to_send = (
-                {input_hash: strings_data_copy[input_hash]} 
-                if input_hash in strings_data_copy 
+                {input_hash: strings_data_copy[input_hash]}
+                if input_hash in strings_data_copy
                 else {}
             )
 

--- a/plugin_source/menu.py
+++ b/plugin_source/menu.py
@@ -22,7 +22,8 @@ links_menu = QMenu('Links', mw)
 
 # Main Actions
 edit_list_action = QAction('Edit Subscriptions', mw)
-push_deck_action = QAction('Publish new Deck', mw)
+push_deck_action = QAction('Publish New Deck', mw)
+push_all_stats_action = QAction('Submit All Review History', mw)
 pull_changes_action = QAction('Check for New Content', mw)
 login_manager_action = QAction('Login', mw) # Default text is Login
 media_import_action = QAction('Import Media from Folder', mw)
@@ -134,17 +135,14 @@ def on_edit_list():
     # table.setColumnWidth(1, int(dialog.width() * 0.45))
     table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows) # Select whole rows
 
-    if strings_data is not None:
-        row = 0
-        for string, data in strings_data.items():
-            if string == "settings" or string == "auth":
-                continue
-
-            item1 = QTableWidgetItem(string)
+    row = 0
+    with DeckConfigManager() as decks:
+        for deck_hash, details in decks:
+            item1 = QTableWidgetItem(deck_hash)
             item1.setFlags(item1.flags() & ~Qt.ItemFlag.ItemIsEditable)
             table.setItem(row, 0, item1)
 
-            local_deck_name = get_local_deck_from_hash(string)
+            local_deck_name = get_local_deck_from_hash(deck_hash)
             item2 = QTableWidgetItem(local_deck_name if local_deck_name else "Not Set")
             item2.setFlags(item2.flags() & ~Qt.ItemFlag.ItemIsEditable)
             table.setItem(row, 1, item2)
@@ -357,6 +355,22 @@ def on_push_deck_action():
 
     dialog.exec()
 
+def on_push_all_stats_action():
+    with DeckConfigManager() as decks:
+        for deck_hash, details in decks:
+            if details['stats_enabled']:
+                # Only upload stats if the user wants to share them
+                share_data, _ = wants_to_share_stats(details)
+                if share_data:
+                    rh = ReviewHistory(deck_hash)
+                    op = QueryOp(
+                        parent=mw,
+                        op=lambda _: rh.upload_review_history(0),
+                        success=lambda _: on_stats_upload_done(show_tooltip=True)
+                    )
+                    op.with_progress(
+                        "Uploading Review History..."
+                    ).run_in_background()
 
 def open_community_site():
     webbrowser.open('https://discord.gg/9x4DRxzqwM')
@@ -456,6 +470,7 @@ def menu_init():
     collab_menu.addSeparator()
     collab_menu.addAction(edit_list_action)
     collab_menu.addAction(push_deck_action)
+    collab_menu.addAction(push_all_stats_action)
     collab_menu.addSeparator()
     collab_menu.addMenu(settings_menu)
     collab_menu.addMenu(links_menu)
@@ -476,6 +491,7 @@ def menu_init():
 
     edit_list_action.triggered.connect(on_edit_list)
     push_deck_action.triggered.connect(on_push_deck_action)
+    push_all_stats_action.triggered.connect(on_push_all_stats_action)
     pull_changes_action.triggered.connect(async_update)
     media_import_action.triggered.connect(on_media_btn)
     website_action.triggered.connect(open_website)

--- a/plugin_source/menu.py
+++ b/plugin_source/menu.py
@@ -366,7 +366,7 @@ def on_push_all_stats_action():
                     op = QueryOp(
                         parent=mw,
                         op=lambda _: rh.upload_review_history(0),
-                        success=lambda _: on_stats_upload_done(show_tooltip=True)
+                        success=on_stats_upload_done
                     )
                     op.with_progress(
                         "Uploading Review History..."

--- a/plugin_source/stats.py
+++ b/plugin_source/stats.py
@@ -1,47 +1,28 @@
 import base64
 import json
+import pprint
+
 from aqt import QApplication, mw
 from collections import defaultdict
 import aqt
-import requests 
+import requests
 import gzip
 
+from .utils import get_did_from_hash, get_deck_and_subdecks
 from .identifier import get_user_hash
 from .var_defs import API_BASE_URL
 
-from anki.errors import NotFoundError
 
 class ReviewHistory:
     def __init__(self, deck_hash):
         self.deck_hash = deck_hash
-        self.deck_id = self.get_did_from_hash(deck_hash)
-        self.deck_ids = self.get_deck_and_subdecks(self.deck_id)
+        self.deck_id = get_did_from_hash(deck_hash)
+        self.deck_ids = get_deck_and_subdecks(self.deck_id)
 
-    def get_did_from_hash(self, deck_hash):
-        strings_data = mw.addonManager.getConfig(__name__)
-        if strings_data:
-            for hash, details in strings_data.items():
-                if hash == deck_hash:
-                    return details["deckId"]
-        return None
-
-    def get_deck_and_subdecks(self, deck_id):
-        if deck_id is None or deck_id == -1 or deck_id == 0:
-            return []
-        deck_ids = [deck_id]
-        try:
-            for subdeck in mw.col.decks.children(deck_id):
-                deck_ids.extend(self.get_deck_and_subdecks(subdeck[1]))                    
-        except NotFoundError:
-            return deck_ids
-        except Exception as e:
-            return deck_ids
-        return deck_ids
-
-    def get_card_data(self, last_upload_date):
+    def get_card_data(self, last_upload_date: int) -> defaultdict:
         # Query to get the card data of the given decks
         query = f"""
-            SELECT cards.id, cards.ord, cards.mod, cards.ivl, cards.factor, cards.reps, cards.lapses, notes.guid, cards.did
+            SELECT cards.id, cards.reps, cards.lapses, notes.guid, cards.did
             FROM cards
             JOIN notes ON cards.nid = notes.id
             WHERE cards.did IN ({', '.join(map(str, self.deck_ids))})
@@ -50,41 +31,41 @@ class ReviewHistory:
         """
         card_data = list(mw.col.db.execute(query))
 
-        notes_by_deck_and_note_guid = defaultdict(lambda: defaultdict(dict))
-        for card in card_data:
-            note_guid = card[-2]
-            deck_id = card[-1]
-            deck_name = mw.col.decks.name(deck_id)
+        notes_by_deck_and_note_guid = defaultdict(lambda: defaultdict(lambda: {
+            'retention': [],
+            'lapses': [],
+            'reps': []
+        }))
 
-            retention = self.calc_retention(card[0])
-            lapses = card[6]
-            reps = card[5]
+        for card_id, reps, lapses, note_guid, deck_id in card_data:
+            deck_name = mw.col.decks.name(deck_id)
+            retention = self.calc_retention(card_id)
 
             # Skip this card if the true retention is invalid
             if retention == -1:
                 continue
-
-            if 'retention' not in notes_by_deck_and_note_guid[deck_name][note_guid]:
-                notes_by_deck_and_note_guid[deck_name][note_guid]['retention'] = []
-            if 'lapses' not in notes_by_deck_and_note_guid[deck_name][note_guid]:
-                notes_by_deck_and_note_guid[deck_name][note_guid]['lapses'] = []
-            if 'reps' not in notes_by_deck_and_note_guid[deck_name][note_guid]:
-                notes_by_deck_and_note_guid[deck_name][note_guid]['reps'] = []
 
             notes_by_deck_and_note_guid[deck_name][note_guid]['retention'].append(retention)
             notes_by_deck_and_note_guid[deck_name][note_guid]['lapses'].append(lapses)
             notes_by_deck_and_note_guid[deck_name][note_guid]['reps'].append(reps)
 
         for deck_name, notes in notes_by_deck_and_note_guid.items():
-            for note_guid, note_data in list(notes.items()):  # Use list to avoid RuntimeError due to dictionary size change during iteration
-                for key in note_data:
-                    note_data[key] = int(sum(note_data[key]) / len(note_data[key])) if note_data[key] else None
+            note_guids_to_remove = []
+
+            for note_guid, note_data in notes.items():
+                for key, values in note_data.items():
+                    if values:
+                        note_data[key] = int(sum(values) / len(values))
+
                 # Remove the note if it has no valid true retentions
                 if not note_data['retention']:
-                    del notes[note_guid]
+                    note_guids_to_remove.append(note_guid)
+
+            for note_guid in note_guids_to_remove:
+                del notes[note_guid]
 
         return notes_by_deck_and_note_guid
-    
+
     def calc_retention(self, card_id):
         flunked, passed = mw.col.db.first("""
         select
@@ -107,9 +88,13 @@ class ReviewHistory:
             'deck_hash': self.deck_hash,
             'review_history': review_history
         }
+        pprint.pprint(json.dumps(data))
         compressed_data = gzip.compress(json.dumps(data).encode('utf-8'))
         based_data = base64.b64encode(compressed_data)
-        response = requests.post(f"{API_BASE_URL}/UploadDeckStats", data=based_data, headers={'Content-Type': 'application/json'}, timeout=30)
+        response = requests.post(f"{API_BASE_URL}/UploadDeckStats",
+                                 data=based_data,
+                                 headers={'Content-Type': 'application/json'},
+                                 timeout=30)
         aqt.mw.taskman.run_on_main(lambda: aqt.utils.tooltip(response.text, parent=QApplication.focusWidget()))
         return
 

--- a/plugin_source/utils.py
+++ b/plugin_source/utils.py
@@ -1,4 +1,5 @@
 import datetime
+import inspect
 from datetime import datetime
 import aqt
 import aqt.utils
@@ -93,6 +94,7 @@ class DeckConfigManager(AbstractContextManager):
         self._raw_data: Dict[str, Dict] = {}
         self._filtered_items: Dict[str, Dict] = {}
 
+
     def __enter__(self) -> "DeckConfigManager":
         self._raw_data = mw.addonManager.getConfig(__name__) or {}
 
@@ -105,7 +107,6 @@ class DeckConfigManager(AbstractContextManager):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
-        print('saved')
         mw.addonManager.writeConfig(__name__, self._raw_data)
 
     def get_by_hash(self, deck_hash: str) -> Optional[Dict]:

--- a/plugin_source/utils.py
+++ b/plugin_source/utils.py
@@ -1,67 +1,71 @@
-
 import datetime
-from datetime import datetime, timedelta
+from datetime import datetime
 import aqt
 import aqt.utils
-import anki
-from anki.utils import point_version
+from anki.errors import NotFoundError
 from aqt.operations import QueryOp
 from anki.collection import Collection
-from aqt.qt import *
 from aqt import mw
 import aqt.utils
+from typing import Optional
+
+def get_timestamp(given_deck_hash):
+    with DeckConfigManager() as decks:
+        details = decks.get_by_hash(given_deck_hash)
+
+        if details is None:
+            return None
+
+        date_string = details["timestamp"]
+        datetime_obj = datetime.strptime(date_string, '%Y-%m-%d %H:%M:%S')
+        unix_timestamp = datetime_obj.timestamp()
+        return unix_timestamp
 
 
-def get_timestamp(deck_hash):
-    strings_data = mw.addonManager.getConfig(__name__)
-    if strings_data:        
-        for sub, details in strings_data.items():
-            if sub == deck_hash:
-                date_string = details["timestamp"]
-                datetime_obj = datetime.strptime(date_string, '%Y-%m-%d %H:%M:%S')
-                unix_timestamp = datetime_obj.timestamp()
-                return unix_timestamp
+def get_hash_from_local_id(deck_id) -> Optional[str]:
+    with DeckConfigManager() as decks:
+        for deck_hash, details in decks:
+            if details.get("deckId") == deck_id:
+                return deck_hash
+
     return None
 
-def get_hash_from_local_id(deck_id):
-    strings_data = mw.addonManager.getConfig(__name__)
-    if strings_data:
-        for hash, details in strings_data.items():
-            if "deckId" in details and details["deckId"] == deck_id:
-                return hash
-    return None
 
 def get_deck_hash_from_did(did):
-    deckHash = get_hash_from_local_id(did)
+    deck_hash = get_hash_from_local_id(did)
     parent = mw.col.decks.parents(did)
-    if not deckHash and parent:
+    if not deck_hash and parent:
         parent_len = len(parent)
         i = 0
-        deckHash = get_hash_from_local_id(did)
-        while i < parent_len and not deckHash:
+        deck_hash = get_hash_from_local_id(did)
+        while i < parent_len and not deck_hash:
             deck_id = parent[parent_len - i - 1]["id"]
-            deckHash = get_hash_from_local_id(deck_id)
+            deck_hash = get_hash_from_local_id(deck_id)
             i += 1
-    return deckHash
+    return deck_hash
 
-def get_did_from_hash(deck_hash):
-    strings_data = mw.addonManager.getConfig(__name__)
-    if strings_data:
-        for hash, details in strings_data.items():
-            if hash == deck_hash:
-                return details["deckId"]
-    return None
+
+def get_did_from_hash(given_deck_hash):
+    with DeckConfigManager() as decks:
+        details = decks.get_by_hash(given_deck_hash)
+
+        return details and details.get("deckId")
+
 
 def get_local_deck_from_hash(input_hash):
-    strings_data = mw.addonManager.getConfig(__name__)
-    if strings_data:
-        for hash, details in strings_data.items():
-            if hash == input_hash:
-                return mw.col.decks.name(details["deckId"])
-    return "None"
+    deck_id = get_did_from_hash(input_hash)
+
+    if deck_id is None:
+        return "None"
+
+    return mw.col.decks.name(deck_id)
+
+def get_local_deck_from_id(deck_id):
+    return mw.col.decks.name(deck_id)
 
 def create_backup(background: bool = False):
     print("Creating backup...")
+
     def do_backup(col: Collection):
         try:
             _ = col.create_backup(
@@ -71,12 +75,56 @@ def create_backup(background: bool = False):
             )
         except Exception as e:
             print(f"Error creating backup: {e}")
-            
+
     if background:
         QueryOp(
-                parent=mw,
-                op=do_backup,
-                success=lambda _: 1,
-            ).run_in_background()
+            parent=mw,
+            op=do_backup,
+            success=lambda _: 1,
+        ).run_in_background()
     else:
         do_backup(aqt.mw.col)
+
+from contextlib import AbstractContextManager
+from typing import Dict, Iterator, Optional, Tuple
+
+class DeckConfigManager(AbstractContextManager):
+    def __init__(self):
+        self._raw_data: Dict[str, Dict] = {}
+        self._filtered_items: Dict[str, Dict] = {}
+
+    def __enter__(self) -> "DeckConfigManager":
+        self._raw_data = mw.addonManager.getConfig(__name__) or {}
+
+        self._filtered_items = {
+            deck_hash: details
+            for deck_hash, details in self._raw_data.items()
+            if deck_hash not in ['settings', 'auth']
+        }
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        print('saved')
+        mw.addonManager.writeConfig(__name__, self._raw_data)
+
+    def get_by_hash(self, deck_hash: str) -> Optional[Dict]:
+        return self._filtered_items.get(deck_hash)
+
+    def __iter__(self) -> Iterator[Tuple[str, Dict]]:
+        return iter(self._filtered_items.items())
+
+
+
+def get_deck_and_subdecks(deck_id):
+    if deck_id is None or deck_id == -1 or deck_id == 0:
+        return []
+    deck_ids = [deck_id]
+    try:
+        for subdeck in mw.col.decks.children(deck_id):
+            deck_ids.extend(get_deck_and_subdecks(subdeck[1]))
+    except NotFoundError:
+        return deck_ids
+    except Exception as e:
+        return deck_ids
+    return deck_ids


### PR DESCRIPTION
This PR aims to 

- Fix statistics pushing (current behaviour is that only changed decks will causes statistics to be pushed)
  - Statistics pushing logic happens at the end of update 
- Small refactor of statistics 
  - Remove try catch for divide by zero (more performant to just check)
  - Use defaultdict for keys
  - Move utility functions to utils.py
  - TODO: Use a seperate 'averages' dict to return values (safer, and necessary for future typing)
- Improve deck handling using context manager to implement saving on 'with' exit
  - Simplifies common operations (iterating through decks, getting decks by hash)
  - Refactored some existing deck code to use the new context manager 
- Add a menu item to push all review history
  - This requires adding the deck name to "would you like to submit stats" popup (it is not clear which deck the popup refers to when submitting all stats)
  - Adjust the "Thanks for sharing widget" so that it is correctly placed if a popup is present 
- Linting
  - Removed unused returns
  - Removed unused imports
  - Remove white space
  - TODO?: Add linter? (e.g. ruff)  