### PR TITLE
[Enhancement] Set default state for AnkiCollab suggestion checkbox

### DIFF
--- a/plugin_source/hooks.py
+++ b/plugin_source/hooks.py
@@ -498,6 +498,7 @@ def init_add_card(addCardsDialog):
         return
 
     checkbox = QCheckBox("Suggest on AnkiCollab")
+    checkbox.setChecked(True)
     addCardsDialog.ankicollab_suggest_checkbox = checkbox # Store reference on the dialog instance
 
     button_box = None

--- a/plugin_source/hooks.py
+++ b/plugin_source/hooks.py
@@ -497,8 +497,35 @@ def init_add_card(addCardsDialog):
     if hasattr(addCardsDialog, "ankicollab_suggest_checkbox"):
         return
 
+    cfg = mw.addonManager.getConfig(__name__) or {}
+    settings = cfg.get("settings", {}) if isinstance(cfg, dict) else {}
+    remember_between_sessions = bool(settings.get("remember_suggest_state_between_sessions", False))
+
     checkbox = QCheckBox("Suggest on AnkiCollab")
-    checkbox.setChecked(True)
+    if remember_between_sessions:
+        checkbox.setChecked(bool(settings.get("suggest_on_ankicollab_last_state", True)))
+    else:
+        checkbox.setChecked(True)
+
+    def _persist_suggest_checkbox_state(checked: bool) -> None:
+        # Keep the config read/write localized to this opt-in setting.
+        if not remember_between_sessions:
+            return
+        try:
+            current_cfg = mw.addonManager.getConfig(__name__) or {}
+            if not isinstance(current_cfg, dict):
+                return
+            current_settings = current_cfg.get("settings")
+            if not isinstance(current_settings, dict):
+                current_settings = {}
+                current_cfg["settings"] = current_settings
+            current_settings["suggest_on_ankicollab_last_state"] = bool(checked)
+            mw.addonManager.writeConfig(__name__, current_cfg)
+        except Exception:
+            # Never fail UI init due to settings persistence.
+            pass
+
+    checkbox.toggled.connect(_persist_suggest_checkbox_state)
     addCardsDialog.ankicollab_suggest_checkbox = checkbox # Store reference on the dialog instance
 
     button_box = None

--- a/plugin_source/hooks.py
+++ b/plugin_source/hooks.py
@@ -507,7 +507,7 @@ def init_add_card(addCardsDialog):
     if remember_between_sessions:
         checkbox.setChecked(bool(settings.get("suggest_on_ankicollab_last_state", True)))
     else:
-        checkbox.setChecked(True)
+        checkbox.setChecked(False)
 
     def _persist_suggest_checkbox_state(checked: bool) -> None:
         # Keep the config read/write localized to this opt-in setting.

--- a/plugin_source/hooks.py
+++ b/plugin_source/hooks.py
@@ -501,6 +501,8 @@ def init_add_card(addCardsDialog):
 
     cfg = mw.addonManager.getConfig(__name__) or {}
     settings = cfg.get("settings", {}) if isinstance(cfg, dict) else {}
+    if not isinstance(settings, dict):
+        settings = {}
     remember_between_sessions = bool(settings.get("remember_suggest_state_between_sessions", False))
 
     checkbox = QCheckBox("Suggest on AnkiCollab")

--- a/plugin_source/menu.py
+++ b/plugin_source/menu.py
@@ -1091,13 +1091,20 @@ def show_global_settings_dialog(parent_dialog):
     error_reporting_cb = QCheckBox("Send anonymous error reports (recommended)")
     error_reporting_cb.setChecked(bool(settings.get("error_reporting_enabled", False)))
     error_reporting_cb.setToolTip("Send anonymized crash and error reports to help improve the add-on.")
+
+    remember_suggest_state_cb = QCheckBox("Remember 'Suggest on AnkiCollab' state between sessions")
+    remember_suggest_state_cb.setChecked(bool(settings.get("remember_suggest_state_between_sessions", False)))
+    remember_suggest_state_cb.setToolTip(
+        "When enabled, the add-on will remember whether the 'Suggest on AnkiCollab' checkbox in the Add Cards dialog was last checked or not, even after restarting Anki."
+    )
     
     global_layout.addWidget(pull_on_startup_cb)
     global_layout.addWidget(suspend_new_cards_cb)
     global_layout.addWidget(move_cards_cb)
     global_layout.addWidget(keep_empty_subdecks_cb)
     global_layout.addWidget(auto_approve_cb)
-    
+    global_layout.addWidget(remember_suggest_state_cb)
+     
     # Add to group
     global_layout.addWidget(error_reporting_cb)
     layout.addWidget(global_group)
@@ -1121,6 +1128,7 @@ def show_global_settings_dialog(parent_dialog):
         settings["suspend_new_cards"] = suspend_new_cards_cb.isChecked()
         settings["auto_move_cards"] = move_cards_cb.isChecked()
         settings["keep_empty_subdecks"] = keep_empty_subdecks_cb.isChecked()
+        settings["remember_suggest_state_between_sessions"] = remember_suggest_state_cb.isChecked()
         settings["error_reporting_enabled"] = error_reporting_cb.isChecked()
         mw.addonManager.writeConfig(__name__, strings_data)
         auth_manager.set_auto_approve(auto_approve_cb.isChecked())
@@ -1203,6 +1211,9 @@ def store_default_config():
         "last_ratepls": datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S'),
         "pull_counter": 0,
         "push_counter": 0,
+        # Add Cards: Suggest on AnkiCollab checkbox
+        "remember_suggest_state_between_sessions": False,
+        "suggest_on_ankicollab_last_state": True,
         # Error reporting (Sentry)
         "error_reporting_enabled": False,
     }

--- a/plugin_source/menu.py
+++ b/plugin_source/menu.py
@@ -918,6 +918,7 @@ def show_global_settings_dialog(parent_dialog):
     error_reporting_cb.setToolTip("Help us fix bugs faster - no personal data is collected")
 
     remember_suggest_state_cb = QCheckBox("Remember 'Suggest on AnkiCollab' state between sessions")
+    remember_suggest_state_cb.setStyleSheet(checkbox_style)
     remember_suggest_state_cb.setChecked(bool(settings.get("remember_suggest_state_between_sessions", False)))
     remember_suggest_state_cb.setToolTip(
         "When enabled, the add-on will remember whether the 'Suggest on AnkiCollab' checkbox in the Add Cards dialog was last checked or not, even after restarting Anki."


### PR DESCRIPTION
This pull request makes a minor user experience improvement to the add card dialog in the AnkiCollab plugin. The "Suggest on AnkiCollab" checkbox is now checked by default, making it easier for users to suggest cards.

* The `QCheckBox` for "Suggest on AnkiCollab" in the `init_add_card` function is now set to checked by default (`setChecked(True)`).