### PR TITLE
Keyboard Shortcuts

### DIFF
--- a/plugin_source/hooks.py
+++ b/plugin_source/hooks.py
@@ -77,6 +77,9 @@ def bulk_suggest_handler(browser: Browser, nids: Sequence[NoteId]) -> None:
         return
     suggest_notes(nids, 9)
 
+def trigger_bulk_suggest_from_browser(browser: Browser) -> None:
+    bulk_suggest_handler(browser, browser.selected_notes())
+
 def remove_notes(nids: Sequence[NoteId], window=None) -> None:
     if not auth_manager.is_logged_in():
          showInfo("Please log in to remove notes.", parent=window if window is not None else mw)
@@ -283,7 +286,7 @@ def context_menu_bulk_suggest(browser: Browser, context_menu: QMenu) -> None:
 
     context_menu.addSeparator()
     context_menu.addAction(
-        "AnkiCollab: Bulk suggest notes",
+        "AnkiCollab: Bulk suggest notes\tCtrl+Alt+B",
         lambda: bulk_suggest_handler(browser, nids=selected_nids),
     )
     context_menu.addAction(
@@ -320,6 +323,13 @@ def context_menu_bulk_suggest(browser: Browser, context_menu: QMenu) -> None:
                         )
     except Exception:
         pass
+
+def add_browser_bulk_suggest_action(browser: Browser) -> None:
+    action = QAction("AnkiCollab: Bulk suggest notes", browser)
+    action.setShortcut(QKeySequence("Ctrl+Alt+B"))
+    action.setShortcutContext(Qt.WidgetWithChildrenShortcut)
+    action.triggered.connect(lambda: trigger_bulk_suggest_from_browser(browser))
+    browser.form.menu_Notes.addAction(action)
 
 def create_note_links_handler(browser: Browser, nids: Sequence[NoteId], subscriber_hash: str, base_hash: Optional[str] = None) -> None:
     if not auth_manager.is_logged_in():
@@ -694,6 +704,7 @@ def hooks_init():
         on_deck_browser_will_show_options_menu
     )
     gui_hooks.browser_menus_did_init.append(add_browser_menu_item)
+    gui_hooks.browser_menus_did_init.append(add_browser_bulk_suggest_action)
 
     # Context Menus (callbacks have internal checks)
     gui_hooks.browser_sidebar_will_show_context_menu.append(add_sidebar_context_menu)

--- a/plugin_source/hooks.py
+++ b/plugin_source/hooks.py
@@ -714,8 +714,7 @@ def _get_shortcut(key: str) -> str:
 
 
 def _shortcut_display(key: str) -> str:
-    """Return the shortcut in native macOS display format (e.g. ⌃⌥B), or empty."""
-    raw = _get_shortcut(key)
+    """Return the shortcut in the native platform display format (e.g. ⌃⌥B on macOS), or empty."""
     if not raw:
         return ""
     seq = QKeySequence.fromString(raw)
@@ -736,7 +735,7 @@ def _register_update_decks_shortcut() -> None:
     action.setShortcut(seq)
     action.setShortcutContext(Qt.WindowShortcut)
     action.triggered.connect(lambda: async_update(silent=False))
-
+    mw.addAction(action)
 
 # --- Hook Registration ---
 def hooks_init():

--- a/plugin_source/hooks.py
+++ b/plugin_source/hooks.py
@@ -284,9 +284,15 @@ def context_menu_bulk_suggest(browser: Browser, context_menu: QMenu) -> None:
     selected_nids = browser.selected_notes()
     if not selected_nids: return # Don't add if no notes selected
 
+    # Build bulk-suggest label with shortcut hint if configured
+    bulk_label = "AnkiCollab: Bulk suggest notes"
+    bulk_shortcut = _get_shortcut(SHORTCUT_BULK_SUGGEST)
+    if bulk_shortcut:
+        bulk_label += "\t" + bulk_shortcut
+
     context_menu.addSeparator()
     context_menu.addAction(
-        "AnkiCollab: Bulk suggest notes\tCtrl+Alt+B",
+        bulk_label,
         lambda: bulk_suggest_handler(browser, nids=selected_nids),
     )
     context_menu.addAction(
@@ -325,9 +331,17 @@ def context_menu_bulk_suggest(browser: Browser, context_menu: QMenu) -> None:
         pass
 
 def add_browser_bulk_suggest_action(browser: Browser) -> None:
-    action = QAction("AnkiCollab: Bulk suggest notes", browser)
-    action.setShortcut(QKeySequence("Ctrl+Alt+B"))
-    action.setShortcutContext(Qt.WidgetWithChildrenShortcut)
+    shortcut_str = _get_shortcut(SHORTCUT_BULK_SUGGEST)
+    label = "AnkiCollab: Bulk suggest notes"
+    if shortcut_str:
+        label += "\t" + shortcut_str
+
+    action = QAction(label, browser)
+    if shortcut_str:
+        seq = QKeySequence.fromString(shortcut_str)
+        if not seq.isEmpty():
+            action.setShortcut(seq)
+            action.setShortcutContext(Qt.WidgetWithChildrenShortcut)
     action.triggered.connect(lambda: trigger_bulk_suggest_from_browser(browser))
     browser.form.menu_Notes.addAction(action)
 
@@ -685,12 +699,40 @@ def update_hooks_for_login_state(logged_in: bool):
     #placeholder for future use
     pass
 
+# ── Keyboard Shortcuts ────────────────────────────────────────────────
+
+SHORTCUT_UPDATE_DECKS = "update_decks"
+SHORTCUT_BULK_SUGGEST = "bulk_suggest"
+
+
+def _get_shortcut(key: str) -> str:
+    """Return the configured shortcut string, or empty if not set."""
+    config = mw.addonManager.getConfig(__name__) or {}
+    settings = config.get("settings", {}) if config else {}
+    return settings.get(f"shortcut_{key}", "")
+
+
+def _register_update_decks_shortcut() -> None:
+    """Register the Update Decks shortcut on the main window."""
+    shortcut_str = _get_shortcut(SHORTCUT_UPDATE_DECKS)
+    if not shortcut_str:
+        return
+    seq = QKeySequence.fromString(shortcut_str)
+    if seq.isEmpty():
+        return
+    action = QAction("AnkiCollab: Update Decks", mw)
+    action.setShortcut(seq)
+    action.setShortcutContext(Qt.WindowShortcut)
+    action.triggered.connect(lambda: async_update(silent=False))
+
+
 # --- Hook Registration ---
 def hooks_init():
     """Registers all hooks. Internal checks within callbacks manage behavior."""
     gui_hooks.profile_did_open.append(onProfileLoaded)
     gui_hooks.profile_will_close.append(onProfileWillClose)
     register_sync_refresh_hook()
+    _register_update_decks_shortcut()
 
     # Add Cards related
     gui_hooks.add_cards_did_init.append(init_add_card)

--- a/plugin_source/hooks.py
+++ b/plugin_source/hooks.py
@@ -286,7 +286,7 @@ def context_menu_bulk_suggest(browser: Browser, context_menu: QMenu) -> None:
 
     # Build bulk-suggest label with shortcut hint if configured
     bulk_label = "AnkiCollab: Bulk suggest notes"
-    bulk_shortcut = _get_shortcut(SHORTCUT_BULK_SUGGEST)
+    bulk_shortcut = _shortcut_display(SHORTCUT_BULK_SUGGEST)
     if bulk_shortcut:
         bulk_label += "\t" + bulk_shortcut
 
@@ -332,9 +332,10 @@ def context_menu_bulk_suggest(browser: Browser, context_menu: QMenu) -> None:
 
 def add_browser_bulk_suggest_action(browser: Browser) -> None:
     shortcut_str = _get_shortcut(SHORTCUT_BULK_SUGGEST)
+    shortcut_display = _shortcut_display(SHORTCUT_BULK_SUGGEST)
     label = "AnkiCollab: Bulk suggest notes"
-    if shortcut_str:
-        label += "\t" + shortcut_str
+    if shortcut_display:
+        label += "\t" + shortcut_display
 
     action = QAction(label, browser)
     if shortcut_str:
@@ -710,6 +711,17 @@ def _get_shortcut(key: str) -> str:
     config = mw.addonManager.getConfig(__name__) or {}
     settings = config.get("settings", {}) if config else {}
     return settings.get(f"shortcut_{key}", "")
+
+
+def _shortcut_display(key: str) -> str:
+    """Return the shortcut in native macOS display format (e.g. ⌃⌥B), or empty."""
+    raw = _get_shortcut(key)
+    if not raw:
+        return ""
+    seq = QKeySequence.fromString(raw)
+    if seq.isEmpty():
+        return ""
+    return seq.toString(QKeySequence.NativeText)
 
 
 def _register_update_decks_shortcut() -> None:

--- a/plugin_source/hooks.py
+++ b/plugin_source/hooks.py
@@ -342,7 +342,6 @@ def add_browser_bulk_suggest_action(browser: Browser) -> None:
         seq = QKeySequence.fromString(shortcut_str)
         if not seq.isEmpty():
             action.setShortcut(seq)
-            action.setShortcutContext(Qt.WidgetWithChildrenShortcut)
             action.setShortcutContext(Qt.ShortcutContext.WidgetWithChildrenShortcut)
     action.triggered.connect(lambda: trigger_bulk_suggest_from_browser(browser))
     browser.form.menu_Notes.addAction(action)

--- a/plugin_source/hooks.py
+++ b/plugin_source/hooks.py
@@ -4,7 +4,7 @@ from aqt.browser import Browser, SidebarTreeView, SidebarItem, SidebarItemType
 from anki.decks import DeckId
 from anki.notes import NoteId
 from aqt.qt import *
-from aqt.qt import QMenu, QModelIndex, QCheckBox, QDialogButtonBox, QApplication, QInputDialog
+from aqt.qt import QMenu, QModelIndex, QCheckBox, QDialogButtonBox, QApplication, QInputDialog, QAction, QKeySequence
 from anki import hooks
 from anki.collection import Collection
 from aqt.utils import askUser, showInfo
@@ -736,7 +736,7 @@ def _register_update_decks_shortcut() -> None:
     action.setShortcut(seq)
     action.setShortcutContext(Qt.WindowShortcut)
     action.triggered.connect(lambda: async_update(silent=False))
-
+    mw.addAction(action)
 
 # --- Hook Registration ---
 def hooks_init():

--- a/plugin_source/hooks.py
+++ b/plugin_source/hooks.py
@@ -343,6 +343,7 @@ def add_browser_bulk_suggest_action(browser: Browser) -> None:
         if not seq.isEmpty():
             action.setShortcut(seq)
             action.setShortcutContext(Qt.WidgetWithChildrenShortcut)
+            action.setShortcutContext(Qt.ShortcutContext.WidgetWithChildrenShortcut)
     action.triggered.connect(lambda: trigger_bulk_suggest_from_browser(browser))
     browser.form.menu_Notes.addAction(action)
 
@@ -715,15 +716,15 @@ def _get_shortcut(key: str) -> str:
 
 def _shortcut_display(key: str) -> str:
     """Return the shortcut in the native platform display format (e.g. ⌃⌥B on macOS), or empty."""
+    raw = _get_shortcut(key)
     if not raw:
         return ""
     seq = QKeySequence.fromString(raw)
     if seq.isEmpty():
         return ""
-    return seq.toString(QKeySequence.NativeText)
-
-
-def _register_update_decks_shortcut() -> None:
+    return seq.toString(QKeySequence.SequenceFormat.NativeText)
+ 
+def register_update_decks_shortcut() -> None:
     """Register the Update Decks shortcut on the main window."""
     shortcut_str = _get_shortcut(SHORTCUT_UPDATE_DECKS)
     if not shortcut_str:
@@ -733,7 +734,7 @@ def _register_update_decks_shortcut() -> None:
         return
     action = QAction("AnkiCollab: Update Decks", mw)
     action.setShortcut(seq)
-    action.setShortcutContext(Qt.WindowShortcut)
+    action.setShortcutContext(Qt.ShortcutContext.WindowShortcut)
     action.triggered.connect(lambda: async_update(silent=False))
     mw.addAction(action)
 
@@ -743,7 +744,7 @@ def hooks_init():
     gui_hooks.profile_did_open.append(onProfileLoaded)
     gui_hooks.profile_will_close.append(onProfileWillClose)
     register_sync_refresh_hook()
-    _register_update_decks_shortcut()
+    register_update_decks_shortcut()
 
     # Add Cards related
     gui_hooks.add_cards_did_init.append(init_add_card)

--- a/plugin_source/menu.py
+++ b/plugin_source/menu.py
@@ -1100,9 +1100,11 @@ def show_global_settings_dialog(parent_dialog):
         """Shortcut must be empty or have at least two modifier keys."""
         if seq.isEmpty():
             return True
-        text = seq.toString()
+        text = seq.toString(QKeySequence.PortableText)
+        # If multiple key combinations are present ("Ctrl+Alt+U, Ctrl+Alt+I"), validate the first one.
+        first = text.split(",", 1)[0].strip()
         modifiers = {"Ctrl", "Alt", "Shift", "Meta"}
-        parts = text.split("+")
+        parts = [p.strip() for p in first.split("+") if p.strip()]
         mod_count = sum(1 for p in parts if p in modifiers)
         return mod_count >= 2
 

--- a/plugin_source/menu.py
+++ b/plugin_source/menu.py
@@ -856,7 +856,7 @@ def show_global_settings_dialog(parent_dialog):
     
     dialog = QDialog(parent_dialog)
     dialog.setWindowTitle('Global Settings')
-    dialog.setMinimumSize(420, 420)
+    dialog.setMinimumSize(610, 560)
     dialog.setStyleSheet(get_dialog_style())
     
     layout = QVBoxLayout()
@@ -867,6 +867,18 @@ def show_global_settings_dialog(parent_dialog):
     header_label.setStyleSheet(f"font-size: 16px; font-weight: 500; margin: 10px 0; color: {colors['text_primary']};")
     header_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
     layout.addWidget(header_label)
+
+    # Subscription Info section
+    setting_info_label = QLabel("These settings apply globally to all your subscriptions. Changes take effect on the next import.")
+    setting_info_label.setWordWrap(True)
+    setting_info_label.setStyleSheet(f"""
+        background-color: {colors['info_bg']};
+        border: 1px solid {colors['info_border']};
+        border-radius: 4px;
+        padding: 6px;
+        color: {colors['info_text']};
+    """)
+    layout.addWidget(setting_info_label)
 
     # Get current settings
     strings_data = mw.addonManager.getConfig(__name__)
@@ -884,6 +896,7 @@ def show_global_settings_dialog(parent_dialog):
     # Subscription setting checkboxes
     global_group = QGroupBox("Subscription Settings")
     global_group.setStyleSheet(get_groupbox_style())
+    global_group.setMinimumHeight(200)
     global_layout = QVBoxLayout(global_group)
     
     checkbox_style = f"color: {colors['text_primary']};"
@@ -929,64 +942,98 @@ def show_global_settings_dialog(parent_dialog):
     # Keyboard Shortcuts section
     shortcuts_group = QGroupBox("Keyboard Shortcuts")
     shortcuts_group.setStyleSheet(get_groupbox_style())
-    shortcuts_layout = QVBoxLayout(shortcuts_group)
-    shortcuts_layout.setSpacing(8)
+    shortcuts_group.setMinimumHeight(100)
+    shortcuts_layout = QHBoxLayout(shortcuts_group)
+    shortcuts_layout.setSpacing(16)
 
-    shortcut_label_style = f"color: {colors['text_primary']}; font-size: 13px;"
-    shortcut_hint_style = f"color: {colors['text_muted']}; font-size: 11px;"
+    shortcut_label_style = f"color: {colors['text_primary']}; font-size: 12px; margin-bottom: 2px;"
 
-    # Update Decks shortcut
-    update_row = QHBoxLayout()
-    update_label = QLabel("Update Decks:")
-    update_label.setStyleSheet(shortcut_label_style)
-    update_label.setFixedWidth(120)
-    update_shortcut_edit = QKeySequenceEdit()
-    update_shortcut_edit.setStyleSheet(get_input_style())
-    update_shortcut_edit.setMaximumWidth(180)
-    existing_update = settings.get("shortcut_update_decks", "")
-    if existing_update:
-        update_shortcut_edit.setKeySequence(QKeySequence.fromString(existing_update))
-    update_row.addWidget(update_label)
-    update_row.addWidget(update_shortcut_edit)
-    update_row.addStretch()
-    shortcuts_layout.addLayout(update_row)
+    def _make_hint_icon(tooltip_text: str) -> QLabel:
+        icon = QLabel("?")
+        icon.setToolTip(tooltip_text)
+        icon.setFixedSize(14, 14)
+        icon.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        icon.setStyleSheet(f"""
+            QLabel {{
+                color: {colors['text_muted']};
+                background-color: transparent;
+                border: 1px solid {colors['text_muted']};
+                border-radius: 7px;
+                font-size: 8px;
+                font-weight: bold;
+            }}
+        """)
+        icon.setCursor(Qt.CursorShape.PointingHandCursor)
+        return icon
 
-    update_hint = QLabel("Must contain at least two modifier keys (e.g. Ctrl+Alt+U). Works only in the main Anki window (deck overview).")
-    update_hint.setStyleSheet(shortcut_hint_style)
-    update_hint.setContentsMargins(124, 0, 0, 0)
-    shortcuts_layout.addWidget(update_hint)
+    def _make_shortcut_block(label_text, settings_key, hint_text):
+        block = QWidget()
+        block_layout = QVBoxLayout(block)
+        block_layout.setContentsMargins(0, 0, 0, 0)
+        block_layout.setSpacing(2)
 
-    # Bulk Suggest shortcut
-    bulk_row = QHBoxLayout()
-    bulk_label = QLabel("Bulk Suggest:")
-    bulk_label.setStyleSheet(shortcut_label_style)
-    bulk_label.setFixedWidth(120)
-    bulk_shortcut_edit = QKeySequenceEdit()
-    bulk_shortcut_edit.setStyleSheet(get_input_style())
-    bulk_shortcut_edit.setMaximumWidth(180)
-    existing_bulk = settings.get("shortcut_bulk_suggest", "")
-    if existing_bulk:
-        bulk_shortcut_edit.setKeySequence(QKeySequence.fromString(existing_bulk))
-    bulk_row.addWidget(bulk_label)
-    bulk_row.addWidget(bulk_shortcut_edit)
-    bulk_row.addStretch()
-    shortcuts_layout.addLayout(bulk_row)
+        label = QLabel(label_text)
+        label.setStyleSheet(shortcut_label_style)
+        block_layout.addWidget(label)
 
-    bulk_hint = QLabel("Must contain at least two modifier keys (e.g. Ctrl+Alt+B). Works only in the Browser window.")
-    bulk_hint.setStyleSheet(shortcut_hint_style)
-    bulk_hint.setContentsMargins(124, 0, 0, 0)
-    shortcuts_layout.addWidget(bulk_hint)
+        row = QHBoxLayout()
+        row.setSpacing(4)
+        edit = QKeySequenceEdit()
+        edit.setStyleSheet(get_input_style())
+        edit.setMaximumWidth(120)
+        existing = settings.get(settings_key, "")
+        if existing:
+            edit.setKeySequence(QKeySequence.fromString(existing))
+
+        clear_btn = QPushButton("Clear")
+        clear_btn.setStyleSheet(f"""
+            QPushButton {{
+                background-color: transparent;
+                color: {colors['text_secondary']};
+                border: 1px solid {colors['border']};
+                padding: 2px 10px;
+                border-radius: 3px;
+                font-size: 11px;
+            }}
+            QPushButton:hover {{
+                background-color: {colors['surface_hover']};
+                color: {colors['text_primary']};
+            }}
+        """)
+        clear_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        clear_btn.clicked.connect(edit.clear)
+
+        hint_icon = _make_hint_icon(hint_text)
+
+        row.addWidget(edit)
+        row.addWidget(clear_btn)
+        row.addWidget(hint_icon)
+        block_layout.addLayout(row)
+
+        return block, edit
+
+    update_block, update_shortcut_edit = _make_shortcut_block(
+        "Update Decks:",
+        "shortcut_update_decks",
+        "Must contain at least two modifier keys (e.g. ⌃⌥U). "
+        "Works only in the main Anki window (deck overview).",
+    )
+    shortcuts_layout.addWidget(update_block)
+
+    bulk_block, bulk_shortcut_edit = _make_shortcut_block(
+        "Bulk Suggest:",
+        "shortcut_bulk_suggest",
+        "Must contain at least two modifier keys (e.g. ⌃⌥B). "
+        "Works only in the Browser window.",
+    )
+    shortcuts_layout.addStretch()
+    shortcuts_layout.addWidget(bulk_block)
 
     layout.addWidget(shortcuts_group)
 
-    # Subscription Info section 
-    setting_info_label = QLabel("These settings apply globally to all your subscriptions. Changes take effect on the next import.")
-    setting_info_label.setWordWrap(True)
-    setting_info_label.setStyleSheet(get_info_box_style())
-    layout.addWidget(setting_info_label)
-
     # Media and Statistics container
     media_stats_container = QWidget()
+    media_stats_container.setMinimumHeight(110)
     media_stats_layout = QHBoxLayout(media_stats_container)
     media_stats_layout.setContentsMargins(0, 0, 0, 0)
     media_stats_layout.setSpacing(6)
@@ -1085,7 +1132,7 @@ def show_global_settings_dialog(parent_dialog):
             init_sentry()
         except Exception:
             pass
-        showInfo("Settings saved! Changes will apply on the next sync, restart Anki for new shortcuts to take effect.", parent=dialog)
+        showInfo("Settings saved! Changes will apply on the next sync.", parent=dialog)
         dialog.accept()
 
     save_button.clicked.connect(save_global_settings)
@@ -1204,10 +1251,31 @@ def update_ui_for_login_state():
     if logged_in:
         refresh_notifications()
 
+def _apply_shortcut_hint():
+    """Append the configured shortcut in native format to the Update Decks action text."""
+    config = mw.addonManager.getConfig(__name__) or {}
+    settings = config.get("settings", {}) if config else {}
+    raw = settings.get("shortcut_update_decks", "")
+    if not raw:
+        return
+    seq = QKeySequence.fromString(raw)
+    if seq.isEmpty():
+        return
+    display = seq.toString(QKeySequence.NativeText)
+    if not display:
+        return
+    # Strip any existing shortcut hint before appending
+    label = pull_changes_action.text().split("\t")[0]
+    pull_changes_action.setText(f"{label}\t{display}")
+
+
 def menu_init():
     store_default_config()
 
     mw.form.menubar.addMenu(collab_menu)
+
+    # Show the configured shortcut hint in the menu item label
+    _apply_shortcut_hint()
 
     collab_menu.addAction(pull_changes_action)
     collab_menu.addSeparator()

--- a/plugin_source/menu.py
+++ b/plugin_source/menu.py
@@ -926,6 +926,59 @@ def show_global_settings_dialog(parent_dialog):
     global_layout.addWidget(error_reporting_cb)
     layout.addWidget(global_group)
 
+    # Keyboard Shortcuts section
+    shortcuts_group = QGroupBox("Keyboard Shortcuts")
+    shortcuts_group.setStyleSheet(get_groupbox_style())
+    shortcuts_layout = QVBoxLayout(shortcuts_group)
+    shortcuts_layout.setSpacing(8)
+
+    shortcut_label_style = f"color: {colors['text_primary']}; font-size: 13px;"
+    shortcut_hint_style = f"color: {colors['text_muted']}; font-size: 11px;"
+
+    # Update Decks shortcut
+    update_row = QHBoxLayout()
+    update_label = QLabel("Update Decks:")
+    update_label.setStyleSheet(shortcut_label_style)
+    update_label.setFixedWidth(120)
+    update_shortcut_edit = QKeySequenceEdit()
+    update_shortcut_edit.setStyleSheet(get_input_style())
+    update_shortcut_edit.setMaximumWidth(180)
+    existing_update = settings.get("shortcut_update_decks", "")
+    if existing_update:
+        update_shortcut_edit.setKeySequence(QKeySequence.fromString(existing_update))
+    update_row.addWidget(update_label)
+    update_row.addWidget(update_shortcut_edit)
+    update_row.addStretch()
+    shortcuts_layout.addLayout(update_row)
+
+    update_hint = QLabel("Must contain at least two modifier keys (e.g. Ctrl+Alt+U). Works only in the main Anki window (deck overview).")
+    update_hint.setStyleSheet(shortcut_hint_style)
+    update_hint.setContentsMargins(124, 0, 0, 0)
+    shortcuts_layout.addWidget(update_hint)
+
+    # Bulk Suggest shortcut
+    bulk_row = QHBoxLayout()
+    bulk_label = QLabel("Bulk Suggest:")
+    bulk_label.setStyleSheet(shortcut_label_style)
+    bulk_label.setFixedWidth(120)
+    bulk_shortcut_edit = QKeySequenceEdit()
+    bulk_shortcut_edit.setStyleSheet(get_input_style())
+    bulk_shortcut_edit.setMaximumWidth(180)
+    existing_bulk = settings.get("shortcut_bulk_suggest", "")
+    if existing_bulk:
+        bulk_shortcut_edit.setKeySequence(QKeySequence.fromString(existing_bulk))
+    bulk_row.addWidget(bulk_label)
+    bulk_row.addWidget(bulk_shortcut_edit)
+    bulk_row.addStretch()
+    shortcuts_layout.addLayout(bulk_row)
+
+    bulk_hint = QLabel("Must contain at least two modifier keys (e.g. Ctrl+Alt+B). Works only in the Browser window.")
+    bulk_hint.setStyleSheet(shortcut_hint_style)
+    bulk_hint.setContentsMargins(124, 0, 0, 0)
+    shortcuts_layout.addWidget(bulk_hint)
+
+    layout.addWidget(shortcuts_group)
+
     # Subscription Info section 
     setting_info_label = QLabel("These settings apply globally to all your subscriptions. Changes take effect on the next import.")
     setting_info_label.setWordWrap(True)
@@ -996,13 +1049,35 @@ def show_global_settings_dialog(parent_dialog):
     save_button = QPushButton('Save Settings')
     save_button.setStyleSheet(get_button_style('success'))
 
+    def _validate_shortcut(seq: QKeySequence) -> bool:
+        """Shortcut must be empty or have at least two modifier keys."""
+        if seq.isEmpty():
+            return True
+        text = seq.toString()
+        modifiers = {"Ctrl", "Alt", "Shift", "Meta"}
+        parts = text.split("+")
+        mod_count = sum(1 for p in parts if p in modifiers)
+        return mod_count >= 2
+
     def save_global_settings():
+        # Validate shortcuts before saving
+        update_seq = update_shortcut_edit.keySequence()
+        bulk_seq = bulk_shortcut_edit.keySequence()
+        if not _validate_shortcut(update_seq):
+            showInfo("Update Decks shortcut must use at least two modifier keys (e.g. Ctrl+Alt+U).", parent=dialog)
+            return
+        if not _validate_shortcut(bulk_seq):
+            showInfo("Bulk Suggest shortcut must use at least two modifier keys (e.g. Ctrl+Alt+B).", parent=dialog)
+            return
+
         settings["preserve_deck_structure"] = True
         settings["pull_on_startup"] = pull_on_startup_cb.isChecked()
         settings["suspend_new_cards"] = suspend_new_cards_cb.isChecked()
         settings["auto_move_cards"] = move_cards_cb.isChecked()
         settings["keep_empty_subdecks"] = keep_empty_subdecks_cb.isChecked()
         settings["error_reporting_enabled"] = error_reporting_cb.isChecked()
+        settings["shortcut_update_decks"] = update_seq.toString() if not update_seq.isEmpty() else ""
+        settings["shortcut_bulk_suggest"] = bulk_seq.toString() if not bulk_seq.isEmpty() else ""
         mw.addonManager.writeConfig(__name__, strings_data)
         auth_manager.set_auto_approve(auto_approve_cb.isChecked())
         # Apply telemetry setting immediately
@@ -1010,7 +1085,7 @@ def show_global_settings_dialog(parent_dialog):
             init_sentry()
         except Exception:
             pass
-        showInfo("Settings saved! Changes will apply on the next sync.")
+        showInfo("Settings saved! Changes will apply on the next sync, restart Anki for new shortcuts to take effect.", parent=dialog)
         dialog.accept()
 
     save_button.clicked.connect(save_global_settings)

--- a/plugin_source/menu.py
+++ b/plugin_source/menu.py
@@ -1100,7 +1100,7 @@ def show_global_settings_dialog(parent_dialog):
         """Shortcut must be empty or have at least two modifier keys."""
         if seq.isEmpty():
             return True
-        text = seq.toString(QKeySequence.PortableText)
+        text = seq.toString(QKeySequence.SequenceFormat.PortableText)
         # If multiple key combinations are present ("Ctrl+Alt+U, Ctrl+Alt+I"), validate the first one.
         first = text.split(",", 1)[0].strip()
         modifiers = {"Ctrl", "Alt", "Shift", "Meta"}
@@ -1263,7 +1263,7 @@ def _apply_shortcut_hint():
     seq = QKeySequence.fromString(raw)
     if seq.isEmpty():
         return
-    display = seq.toString(QKeySequence.NativeText)
+    display = seq.toString(QKeySequence.SequenceFormat.NativeText)
     if not display:
         return
     # Strip any existing shortcut hint before appending


### PR DESCRIPTION
introduces configurable global keyboard shortcuts for bulk suggesting and for update decks. slight redesign of settings dialog was necessary

**Keyboard Shortcuts:**

* Added support for configurable keyboard shortcuts for "Update Decks" and "Bulk Suggest" actions, including logic to retrieve, display, and register these shortcuts
* Registered the "Update Decks" shortcut in the main window and the "Bulk Suggest" shortcut in the browser, ensuring shortcuts are only active in the appropriate context 
* context menus and browser actions display the configured shortcut hints

**Global Settings Dialog Enhancements:**

* "Keyboard Shortcuts" section, allowing users to set or clear shortcuts for "Update Decks" and "Bulk Suggest" with validation (must use at least two modifier keys)
* Moved subscription info section